### PR TITLE
Add the ability to pass buildInfo from the environment variables

### DIFF
--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -273,18 +273,19 @@ export function createMessageBlocks(options: {
       },
     })
   }
-
-  if (missingEnvProperties.length > 0) {
-    blocks.push({
-      type: BLOCK_TYPES.SECTION,
-      text: {
-        type: TEXT_TYPES.MRKDWN,
-        text: formatString(
-          MESSAGES.MISSING_ENV_WARNING,
-          missingEnvProperties.join(', ')
-        ),
-      },
-    })
+  if (!(process.env.CTRF_SKIP_WARNINGS === 'true')) {
+    if (missingEnvProperties.length > 0) {
+      blocks.push({
+        type: BLOCK_TYPES.SECTION,
+        text: {
+          type: TEXT_TYPES.MRKDWN,
+          text: formatString(
+            MESSAGES.MISSING_ENV_WARNING,
+            missingEnvProperties.join(', ')
+          ),
+        },
+      })
+    }
   }
 
   blocks.push({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,7 +42,7 @@ export const MESSAGES = {
   TOTAL_FAILED_TESTS: '*Total Failed Tests:* {0}',
   MESSAGE_PREFIX: '*Message:* ',
   BUILD_PREFIX: '*Build:* ',
-  MISSING_ENV_WARNING: `${EMOJIS.WARNING} Missing environment properties: {0}. Add these to your CTRF report for a better experience.`,
+  MISSING_ENV_WARNING: `${EMOJIS.WARNING} Missing environment properties: {0}. Add these to your CTRF report for a better experience. Or use environment variables in SCREAMING_SNAKE_CASE format.`,
   FOOTER_TEXT: `<https://github.com/ctrf-io/slack-ctrf|Slack Test Reporter> by <https://ctrf.io|CTRF ${EMOJIS.GREEN_HEART}>`,
 }
 

--- a/src/message-formatter.ts
+++ b/src/message-formatter.ts
@@ -335,15 +335,25 @@ function handleBuildInfo(environment: CtrfEnvironment | undefined): {
 } {
   const missingEnvProperties: string[] = []
 
-  if (environment === undefined) {
+  // Extract build info from process.env or environment as fallback
+  const buildName =
+    process.env.BUILD_NAME ?? environment?.buildName ?? undefined
+  const buildNumber =
+    process.env.BUILD_NUMBER ?? environment?.buildNumber ?? undefined
+  const buildUrl = process.env.BUILD_URL ?? environment?.buildUrl ?? undefined
+
+  // If no environment and no process.env values, return early
+  if (
+    environment === undefined &&
+    buildName === undefined &&
+    buildNumber === undefined &&
+    buildUrl === undefined
+  ) {
     return {
       buildInfo: MESSAGES.NO_BUILD_INFO,
       missingEnvProperties: ['buildName', 'buildNumber', 'buildUrl'],
     }
   }
-
-  const { buildName, buildNumber, buildUrl } = environment
-
   if (buildName === undefined) missingEnvProperties.push('buildName')
   if (buildNumber === undefined) missingEnvProperties.push('buildNumber')
   if (buildUrl === undefined) missingEnvProperties.push('buildUrl')


### PR DESCRIPTION
Some (most) reporters don't push anything to the environment section.
Which causes this
<img width="603" alt="image" src="https://github.com/user-attachments/assets/40929a30-0230-42dd-93a6-e6d55ce67394" />

So I added env vars here:
```bash
BUILD_NAME=ctrf BUILD_NUMBER=123 BUILD_URL='http://google.com' tsx src/cli.ts results 'ctrf-report.json' --oauth-token=xoxb**** --channel-id=C**** -t=qqq -p=prefix -s=suffix   
```
<img width="377" alt="image" src="https://github.com/user-attachments/assets/db490e20-8b14-411a-997b-0baa2920ba7c" />
