### PR TITLE
Skip footer

### DIFF
--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -287,15 +287,17 @@ export function createMessageBlocks(options: {
     })
   }
 
-  blocks.push({
-    type: BLOCK_TYPES.CONTEXT,
-    elements: [
-      {
-        type: TEXT_TYPES.MRKDWN,
-        text: MESSAGES.FOOTER_TEXT,
-      },
-    ],
-  })
+  if (!(process.env.CTRF_SKIP_FOOTER === 'true')) {
+    blocks.push({
+      type: BLOCK_TYPES.CONTEXT,
+      elements: [
+        {
+          type: TEXT_TYPES.MRKDWN,
+          text: MESSAGES.FOOTER_TEXT,
+        },
+      ],
+    })
+  }
 
   return blocks
 }

--- a/src/message-formatter.ts
+++ b/src/message-formatter.ts
@@ -273,15 +273,17 @@ export const formatCustomBlockKitMessage = (
   report: CtrfReport,
   blockKit: any
 ): object | null => {
-  blockKit.blocks.push({
-    type: BLOCK_TYPES.CONTEXT,
-    elements: [
-      {
-        type: TEXT_TYPES.MRKDWN,
-        text: MESSAGES.FOOTER_TEXT,
-      },
-    ],
-  })
+  if (!(process.env.CTRF_SKIP_FOOTER === 'true')) {
+    blockKit.blocks.push({
+      type: BLOCK_TYPES.CONTEXT,
+      elements: [
+        {
+          type: TEXT_TYPES.MRKDWN,
+          text: MESSAGES.FOOTER_TEXT,
+        },
+      ],
+    })
+  }
 
   return createSlackMessage(
     blockKit.blocks,


### PR DESCRIPTION
Ability to hide footer with `CTRF_SKIP_FOOTER` env var to make the message clearer.

<img width="379" alt="image" src="https://github.com/user-attachments/assets/478ed8ae-12c1-4633-a01d-9c0a94791343" />

It's nice, but sometimes not needed - everybody knows what the reporter is if it's part of the build. Turned off by default :) 

_My team asked why we have it in every message - and instead of forking it - added this PR_