### PR TITLE
fix: update ctrf imports for 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@slack/web-api": "^7.9.3",
         "@slack/webhook": "^7.0.5",
         "ctrf": "^0.2.0",
+        "glob": "^11.0.0",
         "handlebars": "^4.7.8",
         "handlebars-helpers-ctrf": "^0.0.6",
         "yargs": "^18.0.0"
@@ -2208,6 +2209,23 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ctrf/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ctrf/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2824,17 +2842,24 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2929,30 +2954,6 @@
       },
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/handlebars-helpers-ctrf/node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/has-flag": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@slack/web-api": "^7.9.3",
     "@slack/webhook": "^7.0.5",
     "ctrf": "^0.2.0",
+    "glob": "^11.0.0",
     "handlebars": "^4.7.8",
     "handlebars-helpers-ctrf": "^0.0.6",
     "yargs": "^18.0.0"

--- a/src/ctrf-parser.ts
+++ b/src/ctrf-parser.ts
@@ -1,6 +1,8 @@
 import { type CtrfReport } from './types/ctrf.js'
 import { stripAnsiFromErrors } from './utils/common.js'
-import { mergeReports, readReportsFromGlobPattern, type Report } from 'ctrf'
+import { merge, parse, type CTRFReport } from 'ctrf'
+import { globSync } from 'glob'
+import fs from 'fs'
 
 /**
  * Parse a CTRF file
@@ -9,19 +11,33 @@ import { mergeReports, readReportsFromGlobPattern, type Report } from 'ctrf'
  */
 export function parseCtrfFile(pattern: string): CtrfReport {
   console.log(`Reading CTRF reports from ${pattern}`)
-  const reports: CtrfReport[] = readReportsFromGlobPattern(
-    pattern
-  ) as CtrfReport[]
+  const files = globSync(pattern)
 
-  if (reports.length === 0) {
+  if (files.length === 0) {
     throw new Error(`CTRF report not found at: ${pattern}`)
   }
 
-  const report: CtrfReport =
+  const reports: CTRFReport[] = files
+    .map(file => {
+      try {
+        const content = fs.readFileSync(file, 'utf8')
+        return parse(content)
+      } catch (error) {
+        console.warn(`Failed to read or parse file '${file}':`, error)
+        return null
+      }
+    })
+    .filter((report): report is CTRFReport => report !== null)
+
+  if (reports.length === 0) {
+    throw new Error(`No valid CTRF reports found matching: ${pattern}`)
+  }
+
+  const merged: CtrfReport =
     reports.length > 1
-      ? (mergeReports(reports as Report[]) as CtrfReport)
-      : reports[0]!
-  const processedReport = stripAnsiFromErrors(report)
+      ? (merge(reports) as CtrfReport)
+      : (reports[0] as CtrfReport)
+  const processedReport = stripAnsiFromErrors(merged)
   console.log(`Read ${reports.length} CTRF reports`)
   return processedReport
 }


### PR DESCRIPTION
Fixes build failure after upgrading to `ctrf` ^0.2.0.\n\n**Changes:**\n- Replaced removed `readReportsFromGlobPattern` and `mergeReports` with local implementation using `glob` + `parse`/`merge` from ctrf\n- Added `glob` ^11.0.0 as a dependency\n- Removed unused `Report` type import (repo uses its own local `CtrfReport` type)\n\nBuild and all 24 tests pass.