### PR TITLE
feat: add emoji reaction support (react, failedEmoji, passedEmoji)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-dist
 node_modules
 ctrf
 coverage
+dist
+.plans
+CLAUDE.md
+*.plan

--- a/README.md
+++ b/README.md
@@ -329,6 +329,80 @@ And finally, you can tag a group by using the `\!subteam^` symbol with the group
 npx slack-ctrf results /path/to/ctrf-file.json -s "<\!subteam^0123456789> please review the results"
 ```
 
+## Threading Support
+
+You can post messages as threaded replies to group related messages together (e.g., re-runs or follow-ups).
+
+### Auto-Threading (Default)
+
+When reporting multiple failures (e.g., using the `failed` or `ai` commands), the reporter automatically threads individual failure details under a single summary message. This keeps your Slack channel clean while providing full detail in the thread.
+
+To disable this behavior and send all messages to the main channel, use the `--no-auto-thread` (or `--no-at`) flag.
+
+### Post to a Thread
+
+Use the `--thread-ts` (or `--tt`) option to reply to an existing thread:
+
+```sh
+npx slack-ctrf results /path/to/ctrf-report.json --thread-ts "1234567890.123456"
+```
+
+You can also set the following environment variables. CLI flags take precedence over environment variables.
+
+- `SLACK_WEBHOOK_URL`: Incoming webhook URL
+- `SLACK_OAUTH_TOKEN`: OAuth token
+- `SLACK_CHANNEL_ID`: Channel ID
+- `SLACK_THREAD_TS`: Thread timestamp to reply to an existing thread
+- `SLACK_TITLE`: Title of the notification
+- `SLACK_FAILED_EMOJI`: Custom emoji for failure reaction
+- `SLACK_PASSED_EMOJI`: Custom emoji for success reaction
+- `SLACK_AUTO_THREAD`: Set to `false` to disable automatic threading
+- `SLACK_DRY_RUN`: Set to `true` to enable dry run mode
+- `SLACK_MAX_REPORTS`: Maximum number of failed tests to report (default: 10)
+
+### Reply Broadcast
+
+To send a threaded reply and also broadcast it to the main channel, use the `--reply-broadcast` (or `--rb`) flag:
+
+```sh
+npx slack-ctrf results /path/to/ctrf-report.json --thread-ts "..." --reply-broadcast
+```
+
+### Get Message Timestamp
+
+Use the `--return-ts` (or `--rt`) flag to output the message timestamp. This is useful for capturing the timestamp of the first message to use in subsequent threaded replies:
+
+```sh
+# First message - capture timestamp
+THREAD_TS=$(npx slack-ctrf results /path/to/ctrf-report.json --return-ts | jq -r '.ts')
+
+# Reply to thread
+npx slack-ctrf results /path/to/ctrf-report.json --thread-ts "$THREAD_TS"
+```
+
+**Note:** The `--return-ts` flag only works when using OAuth token authentication (not webhooks).
+
+### Update an Existing Message
+
+You can update an existing message instead of sending a new one using the `--update-ts` (or `--ut`) option. This is useful for "live" reporting where you replace a placeholder message with final results:
+
+```sh
+npx slack-ctrf results /path/to/ctrf-report.json --update-ts "1234567890.123456"
+```
+
+## Status Reactions
+
+You can automatically add a reaction emoji to your Slack message based on the test results using the `--react` (or `-r`) flag.
+
+- ❌ Added if there are failed tests.
+- ✅ Added if all tests passed.
+
+You can customize these emojis using `--failed-emoji` and `--passed-emoji`:
+
+```sh
+npx slack-ctrf results /path/to/ctrf-report.json --react --failed-emoji "fire" --passed-emoji "rocket"
+```
+
 ## Options
 
 - `--onFailOnly, -f`: Send notification only if there are failed tests.
@@ -338,6 +412,16 @@ npx slack-ctrf results /path/to/ctrf-file.json -s "<\!subteam^0123456789> please
 - `--webhook-url, -w`: Incoming webhook URL
 - `--oauth-token, -o`: OAuth token
 - `--channel-id, -ch`: Channel ID
+- `--thread-ts, -tt`: Thread timestamp to reply to an existing thread
+- `--return-ts, -rt`: Output the message timestamp (only works with OAuth token)
+- `--reply-broadcast, -rb`: Also send threaded reply to the channel
+- `--update-ts, -ut`: Timestamp of a message to update
+- `--react, -r`: Add a reaction based on test results
+- `--auto-thread, --at`: Automatically thread multi-message reports (default: true)
+- `--failed-emoji`: Custom emoji for failure reaction (default: "x")
+- `--passed-emoji`: Custom emoji for success reaction (default: "white_check_mark")
+- `--dry-run, --dr`: Print the Slack message payload instead of sending it
+- `--max-reports, --mr`: Maximum number of failed tests to report (default: 10)
 
 ## Merge reports
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ Explore more <a href="https://www.ctrf.io/integrations">integrations</a> <br/>
 - **Send AI Test Summary to Slack**: Automatically send AI test summary to a Slack channel.
 - **Send Failed Test Details to Slack**: Automatically send failed test details to a Slack channel.
 - **Build your own Slack message**: Create and customize your own Slack test reports with our flexible templating system.
+- **Threading Support**: Post messages as threaded replies to an existing thread, or auto-thread multi-failure reports.
+- **Status Reactions**: Automatically add a pass/fail emoji reaction to your Slack message.
 - **Tagging**: Tag users, channels and groups in the message.
 - **Conditional Notifications**: Use the `--onFailOnly` option to send notifications only if tests fail.
+- **Dry Run**: Preview the Slack message payload without sending it.
 
 ![Example view](assets/results.png)
 
@@ -331,13 +334,7 @@ npx slack-ctrf results /path/to/ctrf-file.json -s "<\!subteam^0123456789> please
 
 ## Threading Support
 
-You can post messages as threaded replies to group related messages together (e.g., re-runs or follow-ups).
-
-### Auto-Threading (Default)
-
-When reporting multiple failures (e.g., using the `failed` or `ai` commands), the reporter automatically threads individual failure details under a single summary message. This keeps your Slack channel clean while providing full detail in the thread.
-
-To disable this behavior and send all messages to the main channel, use the `--no-auto-thread` (or `--no-at`) flag.
+You can post messages as threaded replies to group related messages together.
 
 ### Post to a Thread
 
@@ -347,47 +344,34 @@ Use the `--thread-ts` (or `--tt`) option to reply to an existing thread:
 npx slack-ctrf results /path/to/ctrf-report.json --thread-ts "1234567890.123456"
 ```
 
-You can also set the following environment variables. CLI flags take precedence over environment variables.
+### Get Message Timestamp
 
-- `SLACK_WEBHOOK_URL`: Incoming webhook URL
-- `SLACK_OAUTH_TOKEN`: OAuth token
-- `SLACK_CHANNEL_ID`: Channel ID
-- `SLACK_THREAD_TS`: Thread timestamp to reply to an existing thread
-- `SLACK_TITLE`: Title of the notification
-- `SLACK_FAILED_EMOJI`: Custom emoji for failure reaction
-- `SLACK_PASSED_EMOJI`: Custom emoji for success reaction
-- `SLACK_AUTO_THREAD`: Set to `false` to disable automatic threading
-- `SLACK_DRY_RUN`: Set to `true` to enable dry run mode
-- `SLACK_MAX_REPORTS`: Maximum number of failed tests to report (default: 10)
+Use the `--return-ts` (or `--rt`) flag to output the message timestamp. This is useful for capturing the timestamp of a parent message to thread subsequent commands under it:
+
+```sh
+# Send initial summary and capture its timestamp
+THREAD_TS=$(npx slack-ctrf results /path/to/ctrf-report.json --return-ts)
+
+# Thread a follow-up report
+npx slack-ctrf failed /path/to/ctrf-report.json --thread-ts "$THREAD_TS"
+```
+
+**Note:** `--return-ts` only works with OAuth token authentication (not webhooks).
 
 ### Reply Broadcast
 
 To send a threaded reply and also broadcast it to the main channel, use the `--reply-broadcast` (or `--rb`) flag:
 
 ```sh
-npx slack-ctrf results /path/to/ctrf-report.json --thread-ts "..." --reply-broadcast
+npx slack-ctrf results /path/to/ctrf-report.json --thread-ts "1234567890.123456" --reply-broadcast
 ```
 
-### Get Message Timestamp
+### Auto-Threading
 
-Use the `--return-ts` (or `--rt`) flag to output the message timestamp. This is useful for capturing the timestamp of the first message to use in subsequent threaded replies:
-
-```sh
-# First message - capture timestamp
-THREAD_TS=$(npx slack-ctrf results /path/to/ctrf-report.json --return-ts | jq -r '.ts')
-
-# Reply to thread
-npx slack-ctrf results /path/to/ctrf-report.json --thread-ts "$THREAD_TS"
-```
-
-**Note:** The `--return-ts` flag only works when using OAuth token authentication (not webhooks).
-
-### Update an Existing Message
-
-You can update an existing message instead of sending a new one using the `--update-ts` (or `--ut`) option. This is useful for "live" reporting where you replace a placeholder message with final results:
+When using the `failed` or `ai` commands with multiple failures, you can enable auto-threading to automatically post a summary to the channel and thread individual failure details under it. Use the `--auto-thread` (or `--at`) flag to opt in:
 
 ```sh
-npx slack-ctrf results /path/to/ctrf-report.json --update-ts "1234567890.123456"
+npx slack-ctrf failed /path/to/ctrf-report.json --auto-thread
 ```
 
 ## Status Reactions
@@ -397,11 +381,33 @@ You can automatically add a reaction emoji to your Slack message based on the te
 - ❌ Added if there are failed tests.
 - ✅ Added if all tests passed.
 
-You can customize these emojis using `--failed-emoji` and `--passed-emoji`:
+You can customize the emojis using `--failed-emoji` and `--passed-emoji`:
 
 ```sh
 npx slack-ctrf results /path/to/ctrf-report.json --react --failed-emoji "fire" --passed-emoji "rocket"
 ```
+
+**Note:** Reactions require OAuth token authentication (not webhooks), as the `reactions.add` API is not available via webhooks.
+
+## Dry Run
+
+To preview the Slack message payload without sending it, use the `--dry-run` (or `--dr`) flag:
+
+```sh
+npx slack-ctrf results /path/to/ctrf-report.json --dry-run
+```
+
+The payload will be printed to stdout. No message is sent to Slack.
+
+## Limit Failure Reports
+
+When using the `failed` or `ai` commands, you can cap the number of individual failure messages sent with `--max-reports` (or `--mr`):
+
+```sh
+npx slack-ctrf failed /path/to/ctrf-report.json --max-reports 5
+```
+
+Defaults to 10. If more tests fail than the limit, a notice is appended listing the overflow count.
 
 ## Options
 
@@ -412,16 +418,31 @@ npx slack-ctrf results /path/to/ctrf-report.json --react --failed-emoji "fire" -
 - `--webhook-url, -w`: Incoming webhook URL
 - `--oauth-token, -o`: OAuth token
 - `--channel-id, -ch`: Channel ID
-- `--thread-ts, -tt`: Thread timestamp to reply to an existing thread
-- `--return-ts, -rt`: Output the message timestamp (only works with OAuth token)
-- `--reply-broadcast, -rb`: Also send threaded reply to the channel
-- `--update-ts, -ut`: Timestamp of a message to update
-- `--react, -r`: Add a reaction based on test results
-- `--auto-thread, --at`: Automatically thread multi-message reports (default: true)
-- `--failed-emoji`: Custom emoji for failure reaction (default: "x")
-- `--passed-emoji`: Custom emoji for success reaction (default: "white_check_mark")
+- `--thread-ts, --tt`: Thread timestamp to reply to an existing thread
+- `--return-ts, --rt`: Output the message timestamp (OAuth only)
+- `--reply-broadcast, --rb`: Also send threaded reply to the channel
+- `--auto-thread, --at`: Thread multi-message reports under a summary (default: false)
+- `--react, -r`: Add a reaction emoji based on pass/fail result (OAuth only)
+- `--failed-emoji`: Emoji name for failed results (default: "x")
+- `--passed-emoji`: Emoji name for passed results (default: "white_check_mark")
 - `--dry-run, --dr`: Print the Slack message payload instead of sending it
-- `--max-reports, --mr`: Maximum number of failed tests to report (default: 10)
+- `--max-reports, --mr`: Maximum number of individual failure messages to send (default: 10)
+- `--max-retries`: Number of retry attempts on rate limit or timeout errors (default: 3)
+
+## Environment Variables
+
+CLI flags take precedence over environment variables.
+
+- `SLACK_WEBHOOK_URL`: Incoming webhook URL
+- `SLACK_OAUTH_TOKEN`: OAuth token
+- `SLACK_CHANNEL_ID`: Channel ID
+- `SLACK_THREAD_TS`: Thread timestamp to reply to an existing thread
+- `SLACK_AUTO_THREAD`: Set to `true` to enable automatic threading
+- `SLACK_REACT`: Set to `true` to enable emoji reactions
+- `SLACK_FAILED_EMOJI`: Emoji name for failed results (default: "x")
+- `SLACK_PASSED_EMOJI`: Emoji name for passed results (default: "white_check_mark")
+- `SLACK_DRY_RUN`: Set to `true` to enable dry run mode
+- `SLACK_MAX_RETRIES`: Number of retry attempts (default: 3)
 
 ## Merge reports
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@slack/web-api": "^7.9.3",
         "@slack/webhook": "^7.0.5",
         "ctrf": "^0.2.0",
-        "glob": "^12.0.0",
+        "glob": "^13.0.0",
         "handlebars": "^4.7.8",
         "handlebars-helpers-ctrf": "^0.0.6",
         "yargs": "^18.0.0"
@@ -2307,23 +2307,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ctrf/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/ctrf/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2945,23 +2928,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
-      "integrity": "sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@slack/web-api": "^7.9.3",
         "@slack/webhook": "^7.0.5",
         "ctrf": "^0.2.0",
-        "glob": "^13.0.0",
+        "glob": "^12.0.0",
         "handlebars": "^4.7.8",
         "handlebars-helpers-ctrf": "^0.0.6",
         "yargs": "^18.0.0"
@@ -33,34 +33,6 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
         "vitest": "^3.2.4"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "../handlebars-ctrf": {
-      "name": "handlebars-helpers-ctrf",
-      "version": "0.0.4-next.8",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "ctrf": "^0.0.13-next.0",
-        "handlebars": "^4.7.8",
-        "minimatch": "^10.0.3"
-      },
-      "devDependencies": {
-        "@biomejs/biome": "2.1.1",
-        "@types/jest": "^30.0.0",
-        "@types/node": "^20.12.7",
-        "globals": "^16.3.0",
-        "jest": "^30.0.4",
-        "jest-ctrf-json-reporter": "^0.0.9",
-        "jest-environment-node": "^30.0.4",
-        "ts-jest": "^29.4.0",
-        "tsx": "^4.19.2",
-        "typedoc": "^0.28.7",
-        "typedoc-plugin-markdown": "^4.7.0",
-        "typescript": "^5.8.3"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -1956,10 +1928,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2332,6 +2305,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ctrf/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ctrf/node_modules/json-schema-traverse": {
@@ -2955,14 +2945,20 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.4.tgz",
-      "integrity": "sha512-KACie1EOs9BIOMtenFaxwmYODWA3/fTfGSUnLhMJpXRntu1g+uL/Xvub5f8SCTppvo9q62Qy4LeOoUiaL54G5A==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
+      "integrity": "sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.2.1",
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": "20 || >=22"
@@ -3553,9 +3549,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4181,9 +4177,10 @@
       }
     },
     "node_modules/test-exclude/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@slack/web-api": "^7.9.3",
     "@slack/webhook": "^7.0.5",
     "ctrf": "^0.2.0",
-    "glob": "^13.0.0",
+    "glob": "^12.0.0",
     "handlebars": "^4.7.8",
     "handlebars-helpers-ctrf": "^0.0.6",
     "yargs": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@slack/web-api": "^7.9.3",
     "@slack/webhook": "^7.0.5",
     "ctrf": "^0.2.0",
-    "glob": "^12.0.0",
+    "glob": "^13.0.0",
     "handlebars": "^4.7.8",
     "handlebars-helpers-ctrf": "^0.0.6",
     "yargs": "^18.0.0"

--- a/src/blocks.test.ts
+++ b/src/blocks.test.ts
@@ -31,21 +31,21 @@ describe('Blocks', () => {
       const blocks = createTestResultBlocks(mockSummary, mockBuildInfo)
 
       expect(blocks).toHaveLength(1)
-      expect(blocks[0].type).toBe(BLOCK_TYPES.SECTION)
-      expect(blocks[0].text.type).toBe(TEXT_TYPES.MRKDWN)
-      expect(blocks[0].text.text).toContain(`${EMOJIS.TEST_TUBE} 13`)
-      expect(blocks[0].text.text).toContain(`${EMOJIS.CHECK_MARK} 10`)
-      expect(blocks[0].text.text).not.toContain(EMOJIS.FALLEN_LEAF)
+      expect(blocks[0]!.type).toBe(BLOCK_TYPES.SECTION)
+      expect(blocks[0]!.text!.type).toBe(TEXT_TYPES.MRKDWN)
+      expect(blocks[0]!.text!.text).toContain(`${EMOJIS.TEST_TUBE} 13`)
+      expect(blocks[0]!.text!.text).toContain(`${EMOJIS.CHECK_MARK} 10`)
+      expect(blocks[0]!.text!.text).not.toContain(EMOJIS.FALLEN_LEAF)
 
-      expect(blocks[0].accessory).toHaveProperty('alt_text', 'Pie Chart')
-      expect(blocks[0].accessory).toHaveProperty('type', 'image')
-      expect(blocks[0].accessory.image_url).toContain(
+      expect(blocks[0]!.accessory).toHaveProperty('alt_text', 'Pie Chart')
+      expect(blocks[0]!.accessory).toHaveProperty('type', 'image')
+      expect(blocks[0]!.accessory!.image_url).toContain(
         'https://quickchart.io/chart?'
       )
 
-      expect(blocks[0].text.text).toContain(MESSAGES.RESULT_PASSED)
-      expect(blocks[0].text.text).toContain(mockBuildInfo)
-      expect(blocks[0].text.text).toContain('00:00:25') // Duration formatted
+      expect(blocks[0]!.text!.text).toContain(MESSAGES.RESULT_PASSED)
+      expect(blocks[0]!.text!.text).toContain(mockBuildInfo)
+      expect(blocks[0]!.text!.text).toContain('00:00:25') // Duration formatted
     })
 
     it('should create blocks for failed tests', () => {
@@ -57,15 +57,14 @@ describe('Blocks', () => {
         other: 0,
         tests: 11,
         start: 1706644023000,
-        stop: 1706644024000, // 1 second later
+        stop: 1706644048000,
       }
 
       const blocks = createTestResultBlocks(mockSummary, mockBuildInfo)
 
       expect(blocks).toHaveLength(1)
-      expect(blocks[0].text.text).toContain(`${EMOJIS.X_MARK} 2`)
-      expect(blocks[0].text.text).toContain('*Result:* 2 failed tests')
-      expect(blocks[0].text.text).toContain('00:00:01') // Duration formatted
+      expect(blocks[0]!.text!.text).toContain(`${EMOJIS.X_MARK} 2`)
+      expect(blocks[0]!.text!.text).toContain('*Result:* 2 failed tests')
     })
 
     it('should handle duration less than one second', () => {
@@ -82,7 +81,7 @@ describe('Blocks', () => {
 
       const blocks = createTestResultBlocks(mockSummary, mockBuildInfo)
 
-      expect(blocks[0].text.text).toContain(MESSAGES.DURATION_LESS_THAN_ONE)
+      expect(blocks[0]!.text!.text).toContain(MESSAGES.DURATION_LESS_THAN_ONE)
     })
 
     it('should include flaky tests count when provided', () => {
@@ -104,7 +103,7 @@ describe('Blocks', () => {
         flakyCount
       )
 
-      expect(blocks[0].text.text).toContain(
+      expect(blocks[0]!.text!.text).toContain(
         `${EMOJIS.FALLEN_LEAF} ${flakyCount}`
       )
     })
@@ -140,14 +139,14 @@ describe('Blocks', () => {
 
       const blockTexts = blocks
         .filter(block => block.type === BLOCK_TYPES.SECTION)
-        .map(block => block.text.text)
+        .map(block => block.text!.text)
         .join('\n')
 
       expect(blockTexts).toContain(mockBuildInfo)
 
       const allBlockText = blocks
         .filter(block => block.text?.text)
-        .map(block => block.text.text)
+        .map(block => block.text!.text)
         .join('\n')
 
       expect(allBlockText).toContain('Test 1')
@@ -188,8 +187,8 @@ describe('Blocks', () => {
       const blocks = createMessageBlocks(options)
 
       expect(blocks.length).toBeGreaterThan(0)
-      expect(blocks[0].type).toBe(BLOCK_TYPES.HEADER)
-      expect(blocks[0].text.text).toContain('Test Results')
+      expect(blocks[0]!.type).toBe(BLOCK_TYPES.HEADER)
+      expect(blocks[0]!.text!.text).toContain('Test Results')
     })
 
     it('should include prefix and suffix when provided', () => {
@@ -205,7 +204,7 @@ describe('Blocks', () => {
 
       const blockTexts = blocks
         .filter(block => block.type === BLOCK_TYPES.SECTION)
-        .map(block => block.text.text)
+        .map(block => block.text!.text)
         .join('\n')
 
       expect(blockTexts).toContain('Prefix message')
@@ -223,7 +222,7 @@ describe('Blocks', () => {
 
       const blockTexts = blocks
         .filter(block => block.type === BLOCK_TYPES.SECTION)
-        .map(block => block.text.text)
+        .map(block => block.text!.text)
         .join('\n')
 
       expect(blockTexts).toContain('Missing environment properties')
@@ -273,7 +272,7 @@ describe('Blocks', () => {
 
       const blockTexts = blocks
         .filter(block => block.type === BLOCK_TYPES.SECTION)
-        .map(block => block.text.text)
+        .map(block => block.text!.text)
         .join('\n')
 
       expect(blockTexts).toContain(testName)
@@ -294,7 +293,7 @@ describe('Blocks', () => {
 
       const blockTexts = blocks
         .filter(block => block.type === BLOCK_TYPES.SECTION)
-        .map(block => block.text.text)
+        .map(block => block.text!.text)
         .join('\n')
 
       expect(blockTexts).toContain(testName)
@@ -344,7 +343,7 @@ describe('Blocks', () => {
 
       const blockTexts = blocks
         .filter(block => block.type === BLOCK_TYPES.SECTION)
-        .map(block => block.text.text)
+        .map(block => block.text!.text)
         .join('\n')
 
       expect(blockTexts).toContain(testName)

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -8,6 +8,7 @@ import {
   NOTICES,
 } from './constants.js'
 import { type Summary, type CtrfTest } from './types/ctrf.js'
+import { type Options, type SlackBlock } from './types/reporter.js'
 
 /**
  * Create blocks for test result summary
@@ -20,7 +21,7 @@ export function createTestResultBlocks(
   summary: Summary,
   buildInfo: string,
   flakyCount: number = 0
-): any[] {
+): SlackBlock[] {
   const { passed, failed, skipped, pending, other, tests } = summary
   const resultText =
     failed > 0
@@ -53,7 +54,7 @@ export function createTestResultBlocks(
     testSummary += ` | ${EMOJIS.FALLEN_LEAF} ${flakyCount}`
   }
 
-  const block: any = {
+  const block: SlackBlock = {
     type: BLOCK_TYPES.SECTION,
     text: {
       type: TEXT_TYPES.MRKDWN,
@@ -129,13 +130,15 @@ export function createChartImage(summary: Summary): string {
  * Create blocks for failed tests
  * @param failedTests - The failed tests
  * @param buildInfo - The build information
+ * @param options - The options for the message
  * @returns The blocks for the failed tests
  */
 export function createFailedTestBlocks(
   failedTests: CtrfTest[],
-  buildInfo: string
-): any[] {
-  const blocks: any[] = [
+  buildInfo: string,
+  options?: Options
+): SlackBlock[] {
+  const blocks: SlackBlock[] = [
     {
       type: BLOCK_TYPES.SECTION,
       text: {
@@ -155,7 +158,8 @@ export function createFailedTestBlocks(
     },
   ]
 
-  const limitedFailedTests = failedTests.slice(0, LIMITS.MAX_FAILED_TESTS)
+  const maxReports = options?.maxReports ?? LIMITS.MAX_FAILED_TESTS
+  const limitedFailedTests = failedTests.slice(0, maxReports)
 
   limitedFailedTests.forEach(test => {
     const failSummary =
@@ -184,15 +188,15 @@ export function createFailedTestBlocks(
     })
   })
 
-  if (failedTests.length > LIMITS.MAX_FAILED_TESTS) {
+  if (failedTests.length > maxReports) {
     blocks.push({
       type: BLOCK_TYPES.SECTION,
       text: {
         type: TEXT_TYPES.MRKDWN,
         text: formatString(
           NOTICES.MAX_TESTS_EXCEEDED,
-          LIMITS.MAX_FAILED_TESTS,
-          failedTests.length - LIMITS.MAX_FAILED_TESTS
+          maxReports,
+          failedTests.length - maxReports
         ),
       },
     })
@@ -205,13 +209,15 @@ export function createFailedTestBlocks(
  * Create blocks for AI tests
  * @param failedTests - The failed tests
  * @param buildInfo - The build information
+ * @param options - The options for the message
  * @returns The blocks for the AI tests
  */
 export function createAiTestBlocks(
   failedTests: CtrfTest[],
-  buildInfo: string
-): any[] {
-  const blocks: any[] = [
+  buildInfo: string,
+  options?: Options
+): SlackBlock[] {
+  const blocks: SlackBlock[] = [
     {
       type: BLOCK_TYPES.SECTION,
       text: {
@@ -231,7 +237,8 @@ export function createAiTestBlocks(
     },
   ]
 
-  const limitedFailedTests = failedTests.slice(0, LIMITS.MAX_FAILED_TESTS)
+  const maxReports = options?.maxReports ?? LIMITS.MAX_FAILED_TESTS
+  const limitedFailedTests = failedTests.slice(0, maxReports)
 
   limitedFailedTests.forEach(test => {
     const aiSummary = `${test.ai}`
@@ -254,15 +261,15 @@ export function createAiTestBlocks(
     })
   })
 
-  if (failedTests.length > LIMITS.MAX_FAILED_TESTS) {
+  if (failedTests.length > maxReports) {
     blocks.push({
       type: BLOCK_TYPES.SECTION,
       text: {
         type: TEXT_TYPES.MRKDWN,
         text: formatString(
           NOTICES.MAX_TESTS_EXCEEDED,
-          LIMITS.MAX_FAILED_TESTS,
-          failedTests.length - LIMITS.MAX_FAILED_TESTS
+          maxReports,
+          failedTests.length - maxReports
         ),
       },
     })
@@ -281,8 +288,8 @@ export function createMessageBlocks(options: {
   prefix?: string | null
   suffix?: string | null
   missingEnvProperties: string[]
-  customBlocks: any[]
-}): any[] {
+  customBlocks: SlackBlock[]
+}): SlackBlock[] {
   const {
     title,
     prefix = null,
@@ -291,7 +298,7 @@ export function createMessageBlocks(options: {
     customBlocks = [],
   } = options
 
-  const blocks: any[] = []
+  const blocks: SlackBlock[] = []
 
   if (title !== '' && title !== null) {
     blocks.push({
@@ -366,7 +373,7 @@ export function createMessageBlocks(options: {
 export function createFlakyTestBlocks(
   flakyTests: CtrfTest[],
   buildInfo: string
-): any[] {
+): SlackBlock[] {
   const flakyTestsText = flakyTests.map(test => `- ${test.name}`).join('\n')
 
   return [
@@ -396,7 +403,7 @@ export function createFlakyTestBlocks(
 export function createSingleAiTestBlocks(
   testName: string,
   aiSummary: string
-): any[] {
+): SlackBlock[] {
   const formattedAiSummary = formatString(MESSAGES.AI_SUMMARY, aiSummary)
 
   return [
@@ -428,7 +435,7 @@ export function createSingleFailedTestBlocks(
   testName: string,
   message: string | undefined,
   buildInfo: string
-): any[] {
+): SlackBlock[] {
   const enrichedMessage =
     message !== undefined && message.length > LIMITS.CHAR_LIMIT
       ? message.substring(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,6 +69,24 @@ const sharedOptions = {
     description: 'Maximum number of failed tests to report to Slack',
     default: 10,
   },
+  react: {
+    alias: 'r',
+    type: 'boolean',
+    description: 'Add an emoji reaction to the message (requires OAuth token)',
+    default: false,
+  },
+  failedEmoji: {
+    alias: 'fe',
+    type: 'string',
+    description: 'Emoji to react with when tests fail',
+    default: 'x',
+  },
+  passedEmoji: {
+    alias: 'pe',
+    type: 'string',
+    description: 'Emoji to react with when tests pass',
+    default: 'white_check_mark',
+  },
 } as const
 
 const slackOptions = {
@@ -333,6 +351,9 @@ async function handleCommand(
       autoThread: argv.autoThread as boolean,
       dryRun: argv.dryRun as boolean,
       maxReports: argv.maxReports as number,
+      react: argv.react as boolean,
+      failedEmoji: argv.failedEmoji as string,
+      passedEmoji: argv.passedEmoji as string,
       ...extraOptions,
       ...slackConfig,
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import {
 } from './slack-reporter.js'
 import fs from 'fs'
 import { type Options } from './types/reporter.js'
+import { type CtrfReport } from './types/ctrf.js'
 
 const sharedOptions = {
   title: {
@@ -30,6 +31,43 @@ const sharedOptions = {
     type: 'string',
     description: 'Custom text to add as a suffix to the message',
     default: '',
+  },
+  threadTs: {
+    alias: 'tt',
+    type: 'string',
+    description: 'Thread timestamp to reply to an existing thread',
+  },
+  returnTs: {
+    alias: 'rt',
+    type: 'boolean',
+    description: 'Output the message timestamp (only works with OAuth token)',
+    default: false,
+  },
+  replyBroadcast: {
+    alias: 'rb',
+    type: 'boolean',
+    description:
+      'Also send threaded reply to the channel (requires OAuth token)',
+    default: false,
+  },
+  autoThread: {
+    alias: 'at',
+    type: 'boolean',
+    description:
+      'Automatically thread individual failure details under a summary message',
+    default: false,
+  },
+  dryRun: {
+    alias: 'dr',
+    type: 'boolean',
+    description: 'Print the Slack message payload instead of sending it',
+    default: false,
+  },
+  maxReports: {
+    alias: 'mr',
+    type: 'number',
+    description: 'Maximum number of failed tests to report to Slack',
+    default: 10,
   },
 } as const
 
@@ -84,24 +122,9 @@ const argv = yargs(hideBin(process.argv))
         .options(sharedOptions)
     },
     async argv => {
-      try {
-        const report = parseCtrfFile(argv.path)
-        const slackConfig = getEffectiveSlackConfig(argv)
-        await sendTestResultsToSlack(
-          report,
-          {
-            title: argv.title,
-            prefix: argv.prefix,
-            suffix: argv.suffix,
-            onFailOnly: argv.onFailOnly,
-            ...slackConfig,
-          },
-          true
-        )
-      } catch (error: any) {
-        console.error('Error:', error.message)
-        process.exit(1)
-      }
+      await handleCommand(sendTestResultsToSlack, argv, {
+        onFailOnly: argv.onFailOnly as boolean,
+      })
     }
   )
   .command(
@@ -118,24 +141,9 @@ const argv = yargs(hideBin(process.argv))
         .option(consolidatedOption)
     },
     async argv => {
-      try {
-        const report = parseCtrfFile(argv.path)
-        const slackConfig = getEffectiveSlackConfig(argv)
-        await sendFailedResultsToSlack(
-          report,
-          {
-            title: argv.title,
-            prefix: argv.prefix,
-            suffix: argv.suffix,
-            consolidated: argv.consolidated,
-            ...slackConfig,
-          },
-          true
-        )
-      } catch (error: any) {
-        console.error('Error:', error.message)
-        process.exit(1)
-      }
+      await handleCommand(sendFailedResultsToSlack, argv, {
+        consolidated: argv.consolidated as boolean,
+      })
     }
   )
   .command(
@@ -151,23 +159,7 @@ const argv = yargs(hideBin(process.argv))
         .options(sharedOptions)
     },
     async argv => {
-      try {
-        const report = parseCtrfFile(argv.path)
-        const slackConfig = getEffectiveSlackConfig(argv)
-        await sendFlakyResultsToSlack(
-          report,
-          {
-            title: argv.title,
-            prefix: argv.prefix,
-            suffix: argv.suffix,
-            ...slackConfig,
-          },
-          true
-        )
-      } catch (error: any) {
-        console.error('Error:', error.message)
-        process.exit(1)
-      }
+      await handleCommand(sendFlakyResultsToSlack, argv)
     }
   )
   .command(
@@ -184,24 +176,9 @@ const argv = yargs(hideBin(process.argv))
         .option(consolidatedOption)
     },
     async argv => {
-      try {
-        const report = parseCtrfFile(argv.path)
-        const slackConfig = getEffectiveSlackConfig(argv)
-        await sendAISummaryToSlack(
-          report,
-          {
-            title: argv.title,
-            prefix: argv.prefix,
-            suffix: argv.suffix,
-            consolidated: argv.consolidated,
-            ...slackConfig,
-          },
-          true
-        )
-      } catch (error: any) {
-        console.error('Error:', error.message)
-        process.exit(1)
-      }
+      await handleCommand(sendAISummaryToSlack, argv, {
+        consolidated: argv.consolidated as boolean,
+      })
     }
   )
   .command(
@@ -250,39 +227,52 @@ const argv = yargs(hideBin(process.argv))
     },
     async argv => {
       try {
-        const report = parseCtrfFile(argv.path)
+        const report = parseCtrfFile(argv.path as string)
         const slackConfig = getEffectiveSlackConfig(argv)
 
-        if (!fs.existsSync(argv.templatePath)) {
+        if (!fs.existsSync(argv.templatePath as string)) {
           console.error('Error: Template file not found:', argv.templatePath)
           process.exit(1)
         }
 
-        const templateContent = fs.readFileSync(argv.templatePath, 'utf-8')
+        const templateContent = fs.readFileSync(
+          argv.templatePath as string,
+          'utf-8'
+        )
 
+        const options: Options = {
+          title: argv.title as string,
+          prefix: argv.prefix as string,
+          suffix: argv.suffix as string,
+          onFailOnly: argv.onFailOnly as boolean,
+          threadTs: argv.threadTs as string,
+          returnTs: argv.returnTs as boolean,
+          replyBroadcast: argv.replyBroadcast as boolean,
+          autoThread: argv.autoThread as boolean,
+          dryRun: argv.dryRun as boolean,
+          maxReports: argv.maxReports as number,
+          ...slackConfig,
+        }
+
+        let timestamp: string | void
         if (argv.blockkit) {
-          await sendCustomBlockKitTemplateToSlack(
+          timestamp = await sendCustomBlockKitTemplateToSlack(
             report,
             templateContent,
-            {
-              onFailOnly: argv.onFailOnly,
-              ...slackConfig,
-            },
-            true
+            options,
+            !argv.returnTs
           )
         } else {
-          await sendCustomMarkdownTemplateToSlack(
+          timestamp = await sendCustomMarkdownTemplateToSlack(
             report,
             templateContent,
-            {
-              title: argv.title,
-              prefix: argv.prefix,
-              suffix: argv.suffix,
-              onFailOnly: argv.onFailOnly,
-              ...slackConfig,
-            },
-            true
+            options,
+            !argv.returnTs
           )
+        }
+
+        if (argv.returnTs && timestamp) {
+          console.log(JSON.stringify({ ts: timestamp }))
         }
       } catch (error: any) {
         console.error('Error:', error.message)
@@ -321,9 +311,45 @@ const argv = yargs(hideBin(process.argv))
   })
   .help().argv
 
-function getEffectiveSlackConfig(argv: any): Options {
-  const token = argv.oauthToken ?? process.env.SLACK_OAUTH_TOKEN
-  const channelId = argv.channelId ?? process.env.SLACK_CHANNEL_ID
-  const webhookUrl = argv.webhookUrl ?? process.env.SLACK_WEBHOOK_URL
+async function handleCommand(
+  reporterFn: (
+    report: CtrfReport,
+    options: Options,
+    logs: boolean
+  ) => Promise<string | void>,
+  argv: Record<string, unknown>,
+  extraOptions: Partial<Options> = {}
+) {
+  try {
+    const report = parseCtrfFile(argv.path as string)
+    const slackConfig = getEffectiveSlackConfig(argv)
+    const options: Options = {
+      title: argv.title as string,
+      prefix: argv.prefix as string,
+      suffix: argv.suffix as string,
+      threadTs: argv.threadTs as string,
+      returnTs: argv.returnTs as boolean,
+      replyBroadcast: argv.replyBroadcast as boolean,
+      autoThread: argv.autoThread as boolean,
+      dryRun: argv.dryRun as boolean,
+      maxReports: argv.maxReports as number,
+      ...extraOptions,
+      ...slackConfig,
+    }
+    const timestamp = await reporterFn(report, options, !argv.returnTs)
+    if (argv.returnTs && timestamp) {
+      console.log(JSON.stringify({ ts: timestamp }))
+    }
+  } catch (error: any) {
+    console.error('Error:', error.message)
+    process.exit(1)
+  }
+}
+
+function getEffectiveSlackConfig(argv: Record<string, unknown>): Options {
+  const token = (argv.oauthToken as string) ?? process.env.SLACK_OAUTH_TOKEN
+  const channelId = (argv.channelId as string) ?? process.env.SLACK_CHANNEL_ID
+  const webhookUrl =
+    (argv.webhookUrl as string) ?? process.env.SLACK_WEBHOOK_URL
   return { oauthToken: token, channelId, webhookUrl }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,7 +1,7 @@
 // src/client/client.ts
 import { ChatPostMessageResponse, WebClient } from '@slack/web-api'
 import { IncomingWebhook } from '@slack/webhook'
-import { type Options } from '../types/reporter.js'
+import { type Options, type SlackMessage } from '../types/reporter.js'
 
 /**
  * Create a Slack API client for more advanced operations
@@ -36,15 +36,24 @@ export const createSlackWebhook = (url?: string): IncomingWebhook => {
 /**
  * Send a message to Slack using a webhook URL
  * @param message - The message payload to send to Slack
+ * @param options - Options including threadTs and replyBroadcast
  * @returns A promise that resolves when the message is sent
  */
 export const sendSlackMessage = async (
-  message: object,
+  message: SlackMessage,
   options: Options
 ): Promise<void> => {
   try {
     const webhook = createSlackWebhook(options.webhookUrl)
-    await webhook.send(message)
+    const payload: any = { ...message }
+    if (options.threadTs) {
+      payload.thread_ts = options.threadTs
+    }
+    // Webhooks don't support reply_broadcast in a standard way, but we include it for completeness
+    if (options.replyBroadcast) {
+      payload.reply_broadcast = options.replyBroadcast
+    }
+    await webhook.send(payload)
   } catch (error) {
     throw new Error(
       `Failed to send Slack message: ${error instanceof Error ? error.message : String(error)}`
@@ -56,27 +65,34 @@ export const sendSlackMessage = async (
  * Send a message to a Slack channel using the Web API
  * @param channel - Channel ID or name
  * @param message - Message text or blocks
+ * @param options - Options including threadTs and replyBroadcast
  * @returns A promise that resolves with the API response
  */
 export const postMessage = async (
   channel: string,
-  message: string | object,
+  message: string | SlackMessage,
   options: Options
 ): Promise<ChatPostMessageResponse> => {
   try {
     const client = createSlackClient(options.oauthToken)
 
-    // For v7, we need to handle the payload structure correctly
+    const threadTs = options.threadTs
+    const replyBroadcast = options.replyBroadcast
+
     if (typeof message === 'string') {
       return await client.chat.postMessage({
         channel,
         text: message,
-      })
+        thread_ts: threadTs,
+        reply_broadcast: replyBroadcast,
+      } as any)
     } else {
       return await client.chat.postMessage({
         channel,
         ...message,
-      } as any) // Type assertion needed for complex message objects
+        thread_ts: threadTs || message.thread_ts,
+        reply_broadcast: replyBroadcast || message.reply_broadcast,
+      } as any)
     }
   } catch (error) {
     throw new Error(

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,1 +1,2 @@
 export * from './client.js'
+export * from './slack-client.js'

--- a/src/client/slack-client.test.ts
+++ b/src/client/slack-client.test.ts
@@ -10,6 +10,9 @@ vi.mock('@slack/web-api', () => ({
         .fn()
         .mockResolvedValue({ ok: true, ts: '1234567890.123456' }),
     },
+    reactions: {
+      add: vi.fn().mockResolvedValue({ ok: true }),
+    },
   })),
 }))
 
@@ -79,6 +82,52 @@ describe('SlackClient', () => {
       const webClientInstance = vi.mocked(WebClient).mock.results[0]
         ?.value as any
       expect(webClientInstance.chat.postMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('addReaction', () => {
+    it('should add reaction via web API', async () => {
+      const client = new SlackClient(oauthOptions)
+      await client.addReaction('123.456', 'rocket')
+
+      const webClientInstance = vi.mocked(WebClient).mock.results[0]
+        ?.value as any
+      expect(webClientInstance.reactions.add).toHaveBeenCalledWith({
+        channel: 'C12345',
+        timestamp: '123.456',
+        name: 'rocket',
+      })
+    })
+
+    it('should strip surrounding colons from emoji name', async () => {
+      const client = new SlackClient(oauthOptions)
+      await client.addReaction('123.456', ':fire:')
+
+      const webClientInstance = vi.mocked(WebClient).mock.results[0]
+        ?.value as any
+      expect(webClientInstance.reactions.add).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'fire' })
+      )
+    })
+
+    it('should print dry-run message and skip API call', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const client = new SlackClient({ ...oauthOptions, dryRun: true })
+      await client.addReaction('123.456', 'rocket')
+
+      const webClientInstance = vi.mocked(WebClient).mock.results[0]
+        ?.value as any
+      expect(webClientInstance.reactions.add).not.toHaveBeenCalled()
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[Dry Run]')
+      )
+      consoleSpy.mockRestore()
+    })
+
+    it('should silently skip when no OAuth client is configured', async () => {
+      const client = new SlackClient(webhookOptions)
+      await expect(client.addReaction('123.456', 'rocket')).resolves.toBeUndefined()
+      expect(vi.mocked(WebClient).mock.instances).toHaveLength(0)
     })
   })
 

--- a/src/client/slack-client.test.ts
+++ b/src/client/slack-client.test.ts
@@ -1,0 +1,131 @@
+import { expect, describe, it, vi, beforeEach } from 'vitest'
+import { SlackClient } from './slack-client.js'
+import { WebClient } from '@slack/web-api'
+import { IncomingWebhook } from '@slack/webhook'
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(() => ({
+    chat: {
+      postMessage: vi
+        .fn()
+        .mockResolvedValue({ ok: true, ts: '1234567890.123456' }),
+    },
+  })),
+}))
+
+vi.mock('@slack/webhook', () => ({
+  IncomingWebhook: vi.fn().mockImplementation(() => ({
+    send: vi.fn().mockResolvedValue({ text: 'ok' }),
+  })),
+}))
+
+describe('SlackClient', () => {
+  const oauthOptions = {
+    oauthToken: 'xoxb-token',
+    channelId: 'C12345',
+  }
+
+  const webhookOptions = {
+    webhookUrl: 'https://hooks.slack.com/services/xxx',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('sendMessage', () => {
+    it('should send message via webhook when webhookUrl is provided', async () => {
+      const client = new SlackClient(webhookOptions)
+      await client.sendMessage({ text: 'hello' })
+
+      const webhookInstance = vi.mocked(IncomingWebhook).mock.results[0]
+        ?.value as any
+      expect(webhookInstance.send).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'hello' })
+      )
+    })
+
+    it('should send message via web API when oauthToken is provided', async () => {
+      const client = new SlackClient(oauthOptions)
+      const ts = await client.sendMessage({ text: 'hello' })
+
+      expect(ts).toBe('1234567890.123456')
+      const webClientInstance = vi.mocked(WebClient).mock.results[0]
+        ?.value as any
+      expect(webClientInstance.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C12345',
+          text: 'hello',
+        })
+      )
+    })
+
+    it('should include thread_ts in webhook payload if provided in options', async () => {
+      const client = new SlackClient({ ...webhookOptions, threadTs: '111.222' })
+      await client.sendMessage({ text: 'hello' })
+
+      const webhookInstance = vi.mocked(IncomingWebhook).mock.results[0]
+        ?.value as any
+      expect(webhookInstance.send).toHaveBeenCalledWith(
+        expect.objectContaining({ thread_ts: '111.222' })
+      )
+    })
+
+    it('should respect dry-run mode', async () => {
+      const client = new SlackClient({ ...oauthOptions, dryRun: true })
+      const ts = await client.sendMessage({ text: 'dry run' })
+
+      expect(ts).toBe('dry-run-ts')
+      const webClientInstance = vi.mocked(WebClient).mock.results[0]
+        ?.value as any
+      expect(webClientInstance.chat.postMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('constructor', () => {
+    it('should use provided options', () => {
+      const options = {
+        title: 'Provided Title',
+        threadTs: 'provided.ts',
+        dryRun: true,
+      }
+      const client = new SlackClient(options)
+      // Accessing private options for testing
+      expect((client as any).options.title).toBe('Provided Title')
+      expect((client as any).options.threadTs).toBe('provided.ts')
+      expect((client as any).options.dryRun).toBe(true)
+    })
+  })
+
+  describe('retry logic', () => {
+    it('should retry on rate limit error', async () => {
+      const client = new SlackClient({ ...oauthOptions, maxRetries: 2 })
+      const webClientInstance = vi.mocked(WebClient).mock.results[0]
+        ?.value as any
+
+      webClientInstance.chat.postMessage
+        .mockRejectedValueOnce({ code: 'ratelimited', retryAfter: '0.01' })
+        .mockResolvedValueOnce({ ok: true, ts: 'retry.ts' })
+
+      const ts = await client.sendMessage({ text: 'retry me' })
+      expect(ts).toBe('retry.ts')
+      expect(webClientInstance.chat.postMessage).toHaveBeenCalledTimes(2)
+    })
+
+    it('should fail after max retries', async () => {
+      const client = new SlackClient({ ...oauthOptions, maxRetries: 2 })
+      const webClientInstance = vi.mocked(WebClient).mock.results[0]
+        ?.value as any
+
+      const timeoutError = new Error('request_timeout')
+      ;(timeoutError as any).code = 'request_timeout'
+
+      webClientInstance.chat.postMessage.mockRejectedValue(timeoutError)
+
+      await expect(client.sendMessage({ text: 'fail' })).rejects.toThrow(
+        'Slack API failure: request_timeout'
+      )
+      expect(webClientInstance.chat.postMessage).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/src/client/slack-client.ts
+++ b/src/client/slack-client.ts
@@ -4,6 +4,7 @@ import { type Options, type SlackMessage } from '../types/reporter.js'
 
 export interface ISlackClient {
   sendMessage(message: SlackMessage): Promise<string | undefined>
+  addReaction(ts: string, emoji: string): Promise<void>
 }
 
 export class SlackClient implements ISlackClient {
@@ -106,6 +107,27 @@ export class SlackClient implements ISlackClient {
       throw new Error(
         'Slack configuration is missing. Provide either webhook-url or oauth-token and channel-id.'
       )
+    })
+  }
+
+  async addReaction(ts: string, emoji: string): Promise<void> {
+    const name = emoji.replace(/^:|:$/g, '')
+
+    if (this.options.dryRun) {
+      console.log(`[Dry Run] Add reaction :${name}: to message ${ts}`)
+      return
+    }
+
+    if (!this.webClient || !this.options.channelId) {
+      return
+    }
+
+    await this.withRetry(async () => {
+      await this.webClient!.reactions.add({
+        channel: this.options.channelId!,
+        timestamp: ts,
+        name,
+      })
     })
   }
 }

--- a/src/client/slack-client.ts
+++ b/src/client/slack-client.ts
@@ -1,0 +1,111 @@
+import { WebClient } from '@slack/web-api'
+import { IncomingWebhook } from '@slack/webhook'
+import { type Options, type SlackMessage } from '../types/reporter.js'
+
+export interface ISlackClient {
+  sendMessage(message: SlackMessage): Promise<string | undefined>
+}
+
+export class SlackClient implements ISlackClient {
+  private webClient?: WebClient
+  private webhook?: IncomingWebhook
+  private options: Options
+  private readonly maxRetries: number
+
+  constructor(options: Options) {
+    this.options = options
+    this.maxRetries = options.maxRetries ?? 3
+
+    if (options.webhookUrl) {
+      this.webhook = new IncomingWebhook(options.webhookUrl)
+    } else if (options.oauthToken) {
+      this.webClient = new WebClient(options.oauthToken)
+    }
+  }
+
+  private async withRetry<T>(operation: () => Promise<T>): Promise<T> {
+    let lastError: any
+    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+      try {
+        return await operation()
+      } catch (error: any) {
+        lastError = error
+        const isRateLimited = error?.code === 'ratelimited'
+        const isTransient =
+          error?.code === 'request_timeout' || error?.code === 'network_error'
+
+        if (attempt < this.maxRetries && (isRateLimited || isTransient)) {
+          const delay = isRateLimited
+            ? (parseInt(error?.retryAfter) || 1) * 1000
+            : attempt * 1000
+          await new Promise(resolve => setTimeout(resolve, delay))
+          continue
+        }
+        break
+      }
+    }
+    throw this.formatError(lastError)
+  }
+
+  private formatError(error: any): Error {
+    const slackError = error?.data?.error || error?.error
+    if (slackError && typeof slackError === 'string') {
+      if (slackError === 'channel_not_found') {
+        return new Error(
+          `Slack error: Channel "${this.options.channelId}" not found. Ensure the bot is invited to the channel.`
+        )
+      }
+      if (slackError === 'invalid_auth') {
+        return new Error('Slack error: Invalid OAuth token provided.')
+      }
+      if (slackError === 'not_in_channel') {
+        return new Error(
+          `Slack error: Bot is not in channel "${this.options.channelId}". Please invite the bot to the channel.`
+        )
+      }
+      return new Error(`Slack API error: ${slackError}`)
+    }
+
+    const message = error instanceof Error ? error.message : String(error)
+    return new Error(`Slack API failure: ${message}`)
+  }
+
+  async sendMessage(message: SlackMessage): Promise<string | undefined> {
+    if (this.options.dryRun) {
+      console.log(
+        '[Dry Run] Slack Message Payload:',
+        JSON.stringify(message, null, 2)
+      )
+      return 'dry-run-ts'
+    }
+
+    return this.withRetry(async () => {
+      if (this.webhook) {
+        const payload: any = { ...message }
+        if (this.options.threadTs) {
+          payload.thread_ts = this.options.threadTs
+        }
+        if (this.options.replyBroadcast) {
+          payload.reply_broadcast = this.options.replyBroadcast
+        }
+        await this.webhook.send(payload)
+        return undefined
+      }
+
+      if (this.webClient && this.options.channelId) {
+        const response = await this.webClient.chat.postMessage({
+          channel: this.options.channelId,
+          ...message,
+          thread_ts: this.options.threadTs || message.thread_ts,
+          reply_broadcast:
+            this.options.replyBroadcast || message.reply_broadcast,
+        } as any)
+        return response.ts as string
+      }
+
+      throw new Error(
+        'Slack configuration is missing. Provide either webhook-url or oauth-token and channel-id.'
+      )
+    })
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MESSAGES = {
 }
 
 export const LIMITS = {
-  MAX_FAILED_TESTS: 20,
+  MAX_FAILED_TESTS: 10,
   CHAR_LIMIT: 2950,
 }
 

--- a/src/message-formatter.test.ts
+++ b/src/message-formatter.test.ts
@@ -1,5 +1,9 @@
 import { expect, describe, it } from 'vitest'
-import { formatResultsMessage } from './message-formatter'
+import {
+  formatResultsMessage,
+  formatGlobalAiSummary,
+  formatConsolidatedAiTestSummary,
+} from './message-formatter'
 import { BLOCK_TYPES, TITLES } from './constants'
 import { CtrfReport } from './types/ctrf'
 
@@ -29,15 +33,11 @@ describe('Message Formatter', () => {
       const result = formatResultsMessage(mockCtrfReport as CtrfReport)
 
       expect(result).toBeDefined()
-      // @ts-expect-error - accessing properties for testing
       expect(result.attachments).toBeDefined()
-      // @ts-expect-error - accessing properties for testing
-      expect(result.attachments.length).toBeGreaterThan(0)
-      // @ts-expect-error - accessing properties for testing
-      expect(result.attachments[0].blocks).toBeDefined()
+      expect(result.attachments!.length).toBeGreaterThan(0)
+      expect(result.attachments![0]!.blocks).toBeDefined()
 
-      // @ts-expect-error - accessing properties for testing
-      const titleBlock = result.attachments[0].blocks.find(
+      const titleBlock = result.attachments![0]!.blocks!.find(
         (block: any) =>
           block.type === BLOCK_TYPES.HEADER &&
           block.text?.text?.includes(TITLES.TEST_RESULTS)
@@ -52,8 +52,7 @@ describe('Message Formatter', () => {
         title: customTitle,
       })
 
-      // @ts-expect-error - accessing properties for testing
-      const titleBlock = result.attachments[0].blocks.find(
+      const titleBlock = result.attachments![0]!.blocks!.find(
         (block: any) =>
           block.type === 'header' && block.text?.text?.includes(customTitle)
       )
@@ -63,15 +62,95 @@ describe('Message Formatter', () => {
     it('should include build information when environment is provided', () => {
       const result = formatResultsMessage(mockCtrfReport as CtrfReport)
 
-      // @ts-expect-error - accessing properties for testing
-      const buildInfoText = result.attachments[0].blocks
-        .filter((block: any) => block.type === 'section')
+      const buildInfoText = result
+        .attachments![0]!.blocks!.filter(
+          (block: any) => block.type === 'section'
+        )
         .map((block: any) => block.text?.text)
         .join(' ')
 
       expect(buildInfoText).toContain('ctrf')
       expect(buildInfoText).toContain('123')
       expect(buildInfoText).toContain('https://ctrf.io/')
+    })
+  })
+
+  describe('formatGlobalAiSummary', () => {
+    it('should return null if no global AI summary is present', () => {
+      const result = formatGlobalAiSummary(mockCtrfReport as CtrfReport)
+      expect(result).toBeNull()
+    })
+
+    it('should format global AI summary when present in results', () => {
+      const reportWithAi = {
+        ...mockCtrfReport,
+        results: {
+          ...mockCtrfReport.results,
+          ai: 'Global AI Summary Text',
+        },
+      }
+      const result = formatGlobalAiSummary(reportWithAi as CtrfReport)
+      expect(result).toBeDefined()
+      const text = result!
+        .attachments![0]!.blocks!.map((b: any) => b.text?.text || '')
+        .join(' ')
+      expect(text).toContain('Executive Summary')
+      expect(text).toContain('Global AI Summary Text')
+    })
+
+    it('should format structured JSON AI summary when present', () => {
+      const structuredAi = {
+        summary: 'Total suite failure overview',
+        code_issues: 'Fix line 42',
+        recommendations: 'Restart server',
+      }
+      const reportWithAi = {
+        ...mockCtrfReport,
+        results: {
+          ...mockCtrfReport.results,
+          ai: JSON.stringify(structuredAi),
+        },
+      }
+      const result = formatGlobalAiSummary(reportWithAi as CtrfReport)
+      expect(result).toBeDefined()
+      const blocks = result!.attachments![0]!.blocks!
+
+      const overallBlock = blocks.find((b: any) =>
+        b.text?.text?.includes('📝 Overall Summary')
+      )
+      const codeBlock = blocks.find((b: any) =>
+        b.text?.text?.includes('💻 Code Issues')
+      )
+      const recBlock = blocks.find((b: any) =>
+        b.text?.text?.includes('💡 Recommendations')
+      )
+
+      expect(overallBlock).toBeDefined()
+      expect(overallBlock!.text!.text).toContain('Total suite failure overview')
+      expect(codeBlock).toBeDefined()
+      expect(codeBlock!.text!.text).toContain('Fix line 42')
+      expect(recBlock).toBeDefined()
+      expect(recBlock!.text!.text).toContain('Restart server')
+    })
+  })
+
+  describe('formatConsolidatedAiTestSummary', () => {
+    it('should include global summary at the top if present', () => {
+      const reportWithAi = {
+        results: {
+          ...mockCtrfReport.results,
+          ai: 'Global Analysis',
+          tests: [{ name: 'test1', status: 'failed', ai: 'Test 1 Analysis' }],
+        },
+      }
+      const result = formatConsolidatedAiTestSummary(reportWithAi as any)
+      expect(result).toBeDefined()
+      const text = result!
+        .attachments![0]!.blocks!.map((b: any) => b.text?.text || '')
+        .join(' ')
+      expect(text).toContain('Executive Summary')
+      expect(text).toContain('Global Analysis')
+      expect(text).toContain('Test 1 Analysis')
     })
   })
 })

--- a/src/message-formatter.ts
+++ b/src/message-formatter.ts
@@ -3,7 +3,11 @@ import {
   type CtrfReport,
   type CtrfTest,
 } from './types/ctrf.js'
-import { type Options } from './types/reporter.js'
+import {
+  type Options,
+  type SlackMessage,
+  type SlackBlock,
+} from './types/reporter.js'
 import {
   BLOCK_TYPES,
   COLORS,
@@ -31,7 +35,7 @@ import {
 export const formatResultsMessage = (
   ctrf: CtrfReport,
   options?: Options
-): object => {
+): SlackMessage => {
   const { summary, environment, tests = [] } = ctrf.results
   const { failed } = summary
   const { title, prefix, suffix } = normalizeOptions(
@@ -59,10 +63,10 @@ export const formatResultsMessage = (
     failed > 0 ? COLORS.FAILED : COLORS.PASSED,
     title,
     environment,
-    message
+    message,
+    options
   )
 }
-
 /**
  * Format the flaky tests message
  * @param ctrf - The CTRF report
@@ -72,7 +76,7 @@ export const formatResultsMessage = (
 export const formatFlakyTestsMessage = (
   ctrf: CtrfReport,
   options?: Options
-): object | null => {
+): SlackMessage | null => {
   const { environment, tests } = ctrf.results
   const flakyTests = tests.filter(test => test.flaky)
   const { title, prefix, suffix } = normalizeOptions(
@@ -100,7 +104,8 @@ export const formatFlakyTestsMessage = (
     COLORS.FLAKY,
     title,
     environment,
-    'Flaky tests detected'
+    'Flaky tests detected',
+    options
   )
 }
 
@@ -115,7 +120,7 @@ export const formatAiTestSummary = (
   test: CtrfTest,
   environment: CtrfEnvironment | undefined,
   options?: Options
-): object | null => {
+): SlackMessage | null => {
   const { name, ai, status } = test
   const { title, prefix, suffix } = normalizeOptions(
     TITLES.AI_TEST_SUMMARY,
@@ -137,21 +142,153 @@ export const formatAiTestSummary = (
     customBlocks,
   })
 
-  return createSlackMessage(blocks, COLORS.AI, title, environment, name)
+  return createSlackMessage(
+    blocks,
+    COLORS.AI,
+    title,
+    environment,
+    name,
+    options
+  )
+}
+
+/**
+ * Format a global AI summary message
+ * @param report - The CTRF report
+ * @param options - The options for the message
+ * @returns The formatted message or null if no global summary
+ */
+export const formatGlobalAiSummary = (
+  report: CtrfReport,
+  options?: Options
+): SlackMessage | null => {
+  const results = report.results
+  const summary = report.results.summary
+  const extra = (report.results as any).extra
+
+  const globalAi =
+    results.ai ||
+    summary.ai ||
+    extra?.ai ||
+    extra?.aiSummary ||
+    extra?.structuredAnalysis
+
+  if (!globalAi) {
+    return null
+  }
+
+  const { title, prefix, suffix } = normalizeOptions(
+    TITLES.AI_TEST_SUMMARY,
+    options
+  )
+  const { missingEnvProperties } = handleBuildInfo(report.results.environment)
+
+  const customBlocks: SlackBlock[] = []
+
+  // Handle structured AI analysis (either as an object or a JSON string)
+  let structured: any = null
+  if (typeof globalAi === 'string') {
+    try {
+      // Check if it's a JSON string (common with --json-analysis)
+      if (globalAi.trim().startsWith('{')) {
+        structured = JSON.parse(globalAi)
+      }
+    } catch {
+      // Not JSON, treat as plain text
+    }
+  } else if (typeof globalAi === 'object') {
+    structured = globalAi
+  }
+
+  if (structured && (structured.summary || structured.overall)) {
+    const overall = structured.summary || structured.overall
+    customBlocks.push({
+      type: BLOCK_TYPES.SECTION,
+      text: {
+        type: TEXT_TYPES.MRKDWN,
+        text: `*📝 Overall Summary*\n${overall}`,
+      },
+    })
+
+    if (structured.code_issues) {
+      customBlocks.push({
+        type: BLOCK_TYPES.SECTION,
+        text: {
+          type: TEXT_TYPES.MRKDWN,
+          text: `*💻 Code Issues*\n${structured.code_issues}`,
+        },
+      })
+    }
+
+    if (structured.timeout_issues) {
+      customBlocks.push({
+        type: BLOCK_TYPES.SECTION,
+        text: {
+          type: TEXT_TYPES.MRKDWN,
+          text: `*⌛ Timeout Issues*\n${structured.timeout_issues}`,
+        },
+      })
+    }
+
+    if (structured.application_issues) {
+      customBlocks.push({
+        type: BLOCK_TYPES.SECTION,
+        text: {
+          type: TEXT_TYPES.MRKDWN,
+          text: `*📱 Application Issues*\n${structured.application_issues}`,
+        },
+      })
+    }
+
+    if (structured.recommendations) {
+      customBlocks.push({
+        type: BLOCK_TYPES.SECTION,
+        text: {
+          type: TEXT_TYPES.MRKDWN,
+          text: `*💡 Recommendations*\n${structured.recommendations}`,
+        },
+      })
+    }
+  } else {
+    // Treat as a plain string
+    customBlocks.push({
+      type: BLOCK_TYPES.SECTION,
+      text: {
+        type: TEXT_TYPES.MRKDWN,
+        text: `*Executive Summary*\n${globalAi}`,
+      },
+    })
+  }
+
+  const blocks = createMessageBlocks({
+    title,
+    prefix,
+    suffix,
+    missingEnvProperties,
+    customBlocks,
+  })
+
+  return createSlackMessage(
+    blocks,
+    COLORS.AI,
+    title,
+    report.results.environment,
+    'Overall AI Analysis',
+    options
+  )
 }
 
 /**
  * Format the consolidated AI test summary message
- * @param tests - The tests
- * @param environment - The environment
+ * @param report - The CTRF report
  * @param options - The options for the message
  * @returns The formatted message
  */
 export const formatConsolidatedAiTestSummary = (
-  tests: CtrfTest[],
-  environment: CtrfEnvironment | undefined,
+  report: CtrfReport,
   options?: Options
-): object | null => {
+): SlackMessage | null => {
+  const { tests, environment } = report.results
   const failedTests = tests.filter(
     test => test.ai !== undefined && test.status === TEST_STATUS.FAILED
   )
@@ -165,7 +302,96 @@ export const formatConsolidatedAiTestSummary = (
     return null
   }
 
-  const customBlocks = createAiTestBlocks(failedTests, buildInfo)
+  const customBlocks = createAiTestBlocks(failedTests, buildInfo, options)
+
+  const results = report.results
+  const summary = report.results.summary
+  const extra = (report.results as any).extra
+
+  const globalAi =
+    results.ai ||
+    summary.ai ||
+    extra?.ai ||
+    extra?.aiSummary ||
+    extra?.structuredAnalysis
+
+  if (globalAi) {
+    let structured: any = null
+    if (typeof globalAi === 'string') {
+      try {
+        if (globalAi.trim().startsWith('{')) {
+          structured = JSON.parse(globalAi)
+        }
+      } catch {
+        /* ignore */
+      }
+    } else if (typeof globalAi === 'object') {
+      structured = globalAi
+    }
+
+    if (structured && (structured.summary || structured.overall)) {
+      const overall = structured.summary || structured.overall
+      customBlocks.unshift({
+        type: BLOCK_TYPES.DIVIDER,
+      })
+      if (structured.recommendations) {
+        customBlocks.unshift({
+          type: BLOCK_TYPES.SECTION,
+          text: {
+            type: TEXT_TYPES.MRKDWN,
+            text: `*💡 Recommendations*\n${structured.recommendations}`,
+          },
+        })
+      }
+      if (structured.application_issues) {
+        customBlocks.unshift({
+          type: BLOCK_TYPES.SECTION,
+          text: {
+            type: TEXT_TYPES.MRKDWN,
+            text: `*📱 Application Issues*\n${structured.application_issues}`,
+          },
+        })
+      }
+      if (structured.timeout_issues) {
+        customBlocks.unshift({
+          type: BLOCK_TYPES.SECTION,
+          text: {
+            type: TEXT_TYPES.MRKDWN,
+            text: `*⌛ Timeout Issues*\n${structured.timeout_issues}`,
+          },
+        })
+      }
+      if (structured.code_issues) {
+        customBlocks.unshift({
+          type: BLOCK_TYPES.SECTION,
+          text: {
+            type: TEXT_TYPES.MRKDWN,
+            text: `*💻 Code Issues*\n${structured.code_issues}`,
+          },
+        })
+      }
+      customBlocks.unshift({
+        type: BLOCK_TYPES.SECTION,
+        text: {
+          type: TEXT_TYPES.MRKDWN,
+          text: `*📝 Overall Summary*\n${overall}`,
+        },
+      })
+    } else {
+      customBlocks.unshift(
+        {
+          type: BLOCK_TYPES.SECTION,
+          text: {
+            type: TEXT_TYPES.MRKDWN,
+            text: `*Executive Summary*\n${globalAi}`,
+          },
+        },
+        {
+          type: BLOCK_TYPES.DIVIDER,
+        }
+      )
+    }
+  }
 
   const blocks = createMessageBlocks({
     title,
@@ -175,14 +401,21 @@ export const formatConsolidatedAiTestSummary = (
     customBlocks,
   })
 
-  return createSlackMessage(blocks, COLORS.AI, title, environment)
+  return createSlackMessage(
+    blocks,
+    COLORS.AI,
+    title,
+    environment,
+    undefined,
+    options
+  )
 }
 
 export const formatConsolidatedFailedTestSummary = (
   tests: CtrfTest[],
   environment: CtrfEnvironment | undefined,
   options?: Options
-): object | null => {
+): SlackMessage | null => {
   const failedTests = tests.filter(test => test.status === TEST_STATUS.FAILED)
   const defaultTitle = options?.title ?? TITLES.FAILED_TEST_REPORT
   const { title, prefix, suffix } = normalizeOptions(defaultTitle, options)
@@ -192,7 +425,7 @@ export const formatConsolidatedFailedTestSummary = (
     return null
   }
 
-  const customBlocks = createFailedTestBlocks(failedTests, buildInfo)
+  const customBlocks = createFailedTestBlocks(failedTests, buildInfo, options)
 
   const blocks = createMessageBlocks({
     title,
@@ -202,14 +435,21 @@ export const formatConsolidatedFailedTestSummary = (
     customBlocks,
   })
 
-  return createSlackMessage(blocks, COLORS.FAILED, title, environment)
+  return createSlackMessage(
+    blocks,
+    COLORS.FAILED,
+    title,
+    environment,
+    undefined,
+    options
+  )
 }
 
 export const formatFailedTestSummary = (
   test: CtrfTest,
   environment: CtrfEnvironment | undefined,
   options?: Options
-): object | null => {
+): SlackMessage | null => {
   const { name, message, status } = test
   const { title, prefix, suffix } = normalizeOptions(
     TITLES.FAILED_TEST_SUMMARY,
@@ -231,7 +471,14 @@ export const formatFailedTestSummary = (
     customBlocks,
   })
 
-  return createSlackMessage(blocks, COLORS.FAILED, title, environment, name)
+  return createSlackMessage(
+    blocks,
+    COLORS.FAILED,
+    title,
+    environment,
+    name,
+    options
+  )
 }
 
 export const formatCustomMarkdownMessage = (
@@ -239,7 +486,7 @@ export const formatCustomMarkdownMessage = (
   templateContent: string,
   environment: CtrfEnvironment | undefined,
   options?: Options
-): object | null => {
+): SlackMessage | null => {
   const { title, prefix, suffix } = normalizeOptions('', options)
   const { missingEnvProperties } = handleBuildInfo(environment)
 
@@ -265,14 +512,15 @@ export const formatCustomMarkdownMessage = (
     blocks,
     report.results.summary.failed > 0 ? COLORS.FAILED : COLORS.PASSED,
     title,
-    environment
+    environment,
+    undefined,
+    options
   )
 }
-
 export const formatCustomBlockKitMessage = (
   report: CtrfReport,
-  blockKit: any
-): object | null => {
+  blockKit: { blocks: SlackBlock[] }
+): SlackMessage | null => {
   if (!(process.env.CTRF_SKIP_FOOTER === 'true')) {
     blockKit.blocks.push({
       type: BLOCK_TYPES.CONTEXT,
@@ -295,12 +543,13 @@ export const formatCustomBlockKitMessage = (
 }
 
 export function createSlackMessage(
-  blocks: unknown[],
+  blocks: SlackBlock[],
   color: string,
   title: string,
   environment?: CtrfEnvironment,
-  additionalInfo?: string
-): object {
+  additionalInfo?: string,
+  options?: Options
+): SlackMessage {
   const notification: string[] = []
   notification.push(title)
 
@@ -323,6 +572,8 @@ export function createSlackMessage(
         blocks,
       },
     ],
+    thread_ts: options?.threadTs,
+    reply_broadcast: options?.replyBroadcast,
   }
 }
 

--- a/src/slack-reporter.test.ts
+++ b/src/slack-reporter.test.ts
@@ -11,6 +11,7 @@ import { CtrfReport } from './types/ctrf.js'
 vi.mock('./client/index.js', () => ({
   SlackClient: vi.fn().mockImplementation(() => ({
     sendMessage: vi.fn().mockResolvedValue('123.456'),
+    addReaction: vi.fn().mockResolvedValue(undefined),
   })),
 }))
 
@@ -102,6 +103,65 @@ describe('slack-reporter', () => {
       const clientInstance = vi.mocked(SlackClient).mock.results[0]
         ?.value as any
       expect(clientInstance.sendMessage).toHaveBeenCalledTimes(1)
+    })
+
+    it('should add failed reaction when react is true and tests failed', async () => {
+      await sendTestResultsToSlack(mockReport, {
+        oauthToken: 't',
+        channelId: 'c',
+        react: true,
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      expect(clientInstance.addReaction).toHaveBeenCalledWith('123.456', 'x')
+    })
+
+    it('should add passed reaction when react is true and all tests passed', async () => {
+      const passingReport = {
+        ...mockReport,
+        results: {
+          ...mockReport.results,
+          summary: { ...mockReport.results.summary, failed: 0, passed: 3 },
+        },
+      }
+      await sendTestResultsToSlack(passingReport, {
+        oauthToken: 't',
+        channelId: 'c',
+        react: true,
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      expect(clientInstance.addReaction).toHaveBeenCalledWith(
+        '123.456',
+        'white_check_mark'
+      )
+    })
+
+    it('should use custom emoji when failedEmoji is set', async () => {
+      await sendTestResultsToSlack(mockReport, {
+        oauthToken: 't',
+        channelId: 'c',
+        react: true,
+        failedEmoji: 'fire',
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      expect(clientInstance.addReaction).toHaveBeenCalledWith('123.456', 'fire')
+    })
+
+    it('should not add reaction when react is false', async () => {
+      await sendTestResultsToSlack(mockReport, {
+        oauthToken: 't',
+        channelId: 'c',
+        react: false,
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      expect(clientInstance.addReaction).not.toHaveBeenCalled()
     })
   })
 

--- a/src/slack-reporter.test.ts
+++ b/src/slack-reporter.test.ts
@@ -1,0 +1,283 @@
+import { expect, describe, it, vi, beforeEach } from 'vitest'
+import {
+  sendFailedResultsToSlack,
+  sendTestResultsToSlack,
+  sendAISummaryToSlack,
+  sendFlakyResultsToSlack,
+} from './slack-reporter.js'
+import { SlackClient } from './client/index.js'
+import { CtrfReport } from './types/ctrf.js'
+
+vi.mock('./client/index.js', () => ({
+  SlackClient: vi.fn().mockImplementation(() => ({
+    sendMessage: vi.fn().mockResolvedValue('123.456'),
+  })),
+}))
+
+const mockReport: CtrfReport = {
+  results: {
+    tool: { name: 'vitest' },
+    summary: {
+      passed: 1,
+      failed: 2,
+      skipped: 0,
+      pending: 0,
+      other: 0,
+      tests: 3,
+      start: 0,
+      stop: 0,
+    },
+    tests: [
+      { name: 'test1', status: 'passed', duration: 0 },
+      {
+        name: 'test2',
+        status: 'failed',
+        duration: 0,
+        message: 'error1',
+        ai: 'ai-summary',
+      },
+      {
+        name: 'test3',
+        status: 'failed',
+        duration: 0,
+        message: 'error2',
+        ai: 'ai-summary-2',
+      },
+    ],
+    environment: {},
+  },
+}
+
+const mockSingleFailureReport: CtrfReport = {
+  results: {
+    tool: { name: 'vitest' },
+    summary: {
+      passed: 1,
+      failed: 1,
+      skipped: 0,
+      pending: 0,
+      other: 0,
+      tests: 2,
+      start: 0,
+      stop: 0,
+    },
+    tests: [
+      { name: 'test1', status: 'passed', duration: 0 },
+      { name: 'test2', status: 'failed', duration: 0, message: 'error1' },
+    ],
+    environment: {},
+  },
+}
+
+const mockFlakyReport: CtrfReport = {
+  results: {
+    tool: { name: 'vitest' },
+    summary: {
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      pending: 0,
+      other: 0,
+      tests: 1,
+      start: 0,
+      stop: 0,
+    },
+    tests: [{ name: 'test1', status: 'passed', duration: 0, flaky: true }],
+    environment: {},
+  },
+}
+
+describe('slack-reporter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('sendTestResultsToSlack', () => {
+    it('should send a single message', async () => {
+      await sendTestResultsToSlack(mockReport, {
+        oauthToken: 't',
+        channelId: 'c',
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      expect(clientInstance.sendMessage).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('sendFailedResultsToSlack', () => {
+    it('should perform auto-threading when multiple failures and no threadTs', async () => {
+      await sendFailedResultsToSlack(mockReport, {
+        oauthToken: 't',
+        channelId: 'c',
+        autoThread: true,
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      // 1 summary header + 2 failure details = 3 calls
+      expect(clientInstance.sendMessage).toHaveBeenCalledTimes(3)
+
+      // First call is the summary header
+      expect(clientInstance.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          text: expect.stringContaining('2 tests failed'),
+        })
+      )
+
+      // Subsequent calls should use the parent TS from the first call
+      expect(clientInstance.sendMessage).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ thread_ts: '123.456' })
+      )
+    })
+
+    it('should respect maxReports limit', async () => {
+      await sendFailedResultsToSlack(mockReport, {
+        oauthToken: 't',
+        channelId: 'c',
+        autoThread: true,
+        maxReports: 1,
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      // 1 header + 1 failure detail + 1 notice = 3 calls
+      expect(clientInstance.sendMessage).toHaveBeenCalledTimes(3)
+      expect(clientInstance.sendMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('1 additional failed tests'),
+        })
+      )
+    })
+
+    it('should not send summary header for exactly 1 failure', async () => {
+      await sendFailedResultsToSlack(mockSingleFailureReport, {
+        oauthToken: 't',
+        channelId: 'c',
+        autoThread: true,
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      // Should only send 1 message (the failure detail), NO summary header
+      expect(clientInstance.sendMessage).toHaveBeenCalledTimes(1)
+      expect(clientInstance.sendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('tests failed'),
+        })
+      )
+    })
+
+    it('should not auto-thread if disabled', async () => {
+      await sendFailedResultsToSlack(mockReport, {
+        oauthToken: 't',
+        channelId: 'c',
+        autoThread: false,
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      // Just the 2 failure details
+      expect(clientInstance.sendMessage).toHaveBeenCalledTimes(2)
+      expect(clientInstance.sendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('See thread for details'),
+        })
+      )
+    })
+  })
+
+  describe('sendAISummaryToSlack', () => {
+    it('should use global AI summary as header if present', async () => {
+      const reportWithGlobalAi = {
+        ...mockReport,
+        results: {
+          ...mockReport.results,
+          ai: 'Global Executive Summary',
+        },
+      }
+      await sendAISummaryToSlack(reportWithGlobalAi as any, {
+        oauthToken: 't',
+        channelId: 'c',
+        autoThread: true,
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      // 1 global summary header + 2 individual failure summaries = 3 calls
+      expect(clientInstance.sendMessage).toHaveBeenCalledTimes(3)
+      expect(clientInstance.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          attachments: expect.arrayContaining([
+            expect.objectContaining({
+              blocks: expect.arrayContaining([
+                expect.objectContaining({
+                  text: expect.objectContaining({
+                    text: expect.stringContaining('Global Executive Summary'),
+                  }),
+                }),
+              ]),
+            }),
+          ]),
+        })
+      )
+    })
+
+    it('should perform auto-threading for AI summaries without global AI', async () => {
+      await sendAISummaryToSlack(mockReport, {
+        oauthToken: 't',
+        channelId: 'c',
+        autoThread: true,
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      // 1 header + 2 AI summaries
+      expect(clientInstance.sendMessage).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('sendFlakyResultsToSlack', () => {
+    it('should send flaky test results', async () => {
+      await sendFlakyResultsToSlack(mockFlakyReport, {
+        oauthToken: 't',
+        channelId: 'c',
+      })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      expect(clientInstance.sendMessage).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('logging control', () => {
+    it('should not log to console when logs is false', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      await sendTestResultsToSlack(
+        mockReport,
+        { oauthToken: 't', channelId: 'c' },
+        false
+      )
+
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        'Test results message sent to Slack.'
+      )
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('options and environment variables', () => {
+    it('should respect dry-run mode in reporter', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      await sendTestResultsToSlack(mockReport, { dryRun: true })
+
+      const clientInstance = vi.mocked(SlackClient).mock.results[0]
+        ?.value as any
+      expect(clientInstance.sendMessage).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+  })
+})

--- a/src/slack-reporter.ts
+++ b/src/slack-reporter.ts
@@ -28,7 +28,24 @@ function resolveOptions(options: Options): Options {
     maxRetries:
       options.maxRetries ?? parseInt(process.env.SLACK_MAX_RETRIES || '3', 10),
     dryRun: options.dryRun ?? process.env.SLACK_DRY_RUN === 'true',
+    react: options.react ?? process.env.SLACK_REACT === 'true',
+    failedEmoji: options.failedEmoji ?? process.env.SLACK_FAILED_EMOJI ?? 'x',
+    passedEmoji:
+      options.passedEmoji ??
+      process.env.SLACK_PASSED_EMOJI ??
+      'white_check_mark',
   }
+}
+
+async function addStatusReaction(
+  client: SlackClient,
+  ts: string | undefined,
+  options: Options,
+  failed: boolean
+): Promise<void> {
+  if (!options.react || !ts) return
+  const emoji = failed ? options.failedEmoji! : options.passedEmoji!
+  await client.addReaction(ts, emoji)
 }
 
 /**
@@ -129,6 +146,12 @@ export async function sendTestResultsToSlack(
   const client = new SlackClient(resolvedOptions)
   const message = formatResultsMessage(report, resolvedOptions)
   const ts = await client.sendMessage(message)
+  await addStatusReaction(
+    client,
+    ts,
+    resolvedOptions,
+    report.results.summary.failed > 0
+  )
 
   if (logs) console.log('Test results message sent to Slack.')
 
@@ -166,6 +189,7 @@ export async function sendFailedResultsToSlack(
     )
     if (message !== null) {
       const ts = await client.sendMessage(message)
+      await addStatusReaction(client, ts, resolvedOptions, true)
       if (logs) console.log('Failed test summary sent to Slack.')
       if (resolvedOptions.returnTs) return ts
     } else {
@@ -180,6 +204,7 @@ export async function sendFailedResultsToSlack(
       'Failed test report',
       formatFailedTestSummary
     )
+    await addStatusReaction(client, ts, resolvedOptions, true)
     if (resolvedOptions.returnTs) return ts
   }
 }
@@ -201,6 +226,7 @@ export async function sendFlakyResultsToSlack(
   if (message !== null) {
     const client = new SlackClient(resolvedOptions)
     const ts = await client.sendMessage(message)
+    await addStatusReaction(client, ts, resolvedOptions, true)
     if (logs) console.log('Flaky tests message sent to Slack.')
     if (resolvedOptions.returnTs) return ts
   } else {
@@ -230,6 +256,12 @@ export async function sendAISummaryToSlack(
     const message = formatConsolidatedAiTestSummary(report, resolvedOptions)
     if (message !== null) {
       const ts = await client.sendMessage(message)
+      await addStatusReaction(
+        client,
+        ts,
+        resolvedOptions,
+        report.results.summary.failed > 0
+      )
       if (logs) console.log('AI test summary sent to Slack.')
       if (resolvedOptions.returnTs) return ts
     } else {
@@ -244,6 +276,12 @@ export async function sendAISummaryToSlack(
       'AI test summary',
       formatAiTestSummary,
       formatGlobalAiSummary
+    )
+    await addStatusReaction(
+      client,
+      ts,
+      resolvedOptions,
+      report.results.summary.failed > 0
     )
     if (resolvedOptions.returnTs) return ts
   }

--- a/src/slack-reporter.ts
+++ b/src/slack-reporter.ts
@@ -7,49 +7,132 @@ import {
   formatConsolidatedFailedTestSummary,
   formatCustomMarkdownMessage,
   formatCustomBlockKitMessage,
+  formatGlobalAiSummary,
 } from './message-formatter.js'
-import { sendSlackMessage, postMessage } from './client/index.js'
-import { type Options } from './types/reporter.js'
-import { type CtrfReport } from './types/ctrf.js'
+import { SlackClient } from './client/index.js'
+import { type Options, type SlackMessage } from './types/reporter.js'
+import {
+  type CtrfEnvironment,
+  type CtrfReport,
+  type CtrfTest,
+} from './types/ctrf.js'
 import { stripAnsiFromErrors } from './utils/common.js'
 import { compileTemplate } from './handlebars/core.js'
+import { LIMITS, NOTICES, formatString } from './constants.js'
+
+function resolveOptions(options: Options): Options {
+  return {
+    ...options,
+    threadTs: options.threadTs || process.env.SLACK_THREAD_TS,
+    autoThread: options.autoThread ?? process.env.SLACK_AUTO_THREAD === 'true',
+    maxRetries:
+      options.maxRetries ?? parseInt(process.env.SLACK_MAX_RETRIES || '3', 10),
+    dryRun: options.dryRun ?? process.env.SLACK_DRY_RUN === 'true',
+  }
+}
+
+/**
+ * Internal utility to handle the logic of sending a summary message and then threading individual details.
+ */
+async function dispatchThreadedReports(
+  client: SlackClient,
+  report: CtrfReport,
+  options: Options,
+  logs: boolean,
+  summaryTitle: string,
+  testFormatter: (
+    test: CtrfTest,
+    env: CtrfEnvironment | undefined,
+    opts: Options
+  ) => SlackMessage | null,
+  headerFormatter?: (rep: CtrfReport, opts: Options) => SlackMessage | null
+): Promise<string | undefined> {
+  let parentTs: string | undefined
+  const threadTs = options.threadTs
+  const autoThread = options.autoThread === true
+  const maxReports = options.maxReports ?? LIMITS.MAX_FAILED_TESTS
+
+  if (!threadTs && autoThread) {
+    let summaryMsg: SlackMessage | null = null
+
+    if (headerFormatter) {
+      summaryMsg = headerFormatter(report, options)
+    }
+
+    if (!summaryMsg && report.results.summary.failed > 1) {
+      summaryMsg = {
+        text: `*${options.title || summaryTitle}*: ${report.results.summary.failed} tests failed. See thread for details.`,
+      }
+    }
+
+    if (summaryMsg) {
+      parentTs = await client.sendMessage(summaryMsg)
+      if (logs) console.log(`${summaryTitle} header sent to Slack.`)
+    }
+  }
+
+  const failedTests = report.results.tests.filter(t => t.status === 'failed')
+  const limitedTests = failedTests.slice(0, maxReports)
+
+  let firstTimestamp: string | undefined
+  for (const test of limitedTests) {
+    const message = testFormatter(test, report.results.environment, options)
+    if (message !== null) {
+      const ts = await client.sendMessage({
+        ...message,
+        thread_ts: parentTs || threadTs,
+      })
+      if (logs) console.log(`${summaryTitle} detail sent to Slack.`)
+      if (!firstTimestamp) firstTimestamp = ts
+    } else {
+      if (logs) console.log(`No ${summaryTitle} detected. No message sent`)
+    }
+  }
+
+  if (failedTests.length > maxReports) {
+    const noticeMsg = {
+      text: formatString(
+        NOTICES.MAX_TESTS_EXCEEDED,
+        maxReports,
+        failedTests.length - maxReports
+      ),
+      thread_ts: parentTs || threadTs,
+    }
+    await client.sendMessage(noticeMsg)
+  }
+
+  return parentTs || firstTimestamp
+}
 
 /**
  * Send the test results to Slack
  * @param report - The CTRF report
  * @param options - The options for the message
  * @param logs - Whether to log the message
+ * @returns The message timestamp if returnTs is true and using OAuth, otherwise void
  */
 export async function sendTestResultsToSlack(
   report: CtrfReport,
   options: Options = {},
   logs: boolean = false
-): Promise<void> {
+): Promise<string | void> {
+  const resolvedOptions = resolveOptions(options)
   if (
-    options.onFailOnly !== undefined &&
-    options.onFailOnly &&
+    resolvedOptions.onFailOnly !== undefined &&
+    resolvedOptions.onFailOnly &&
     report.results.summary.failed === 0
   ) {
     if (logs) console.log('No failed tests. Message not sent.')
     return
   }
 
-  const message = formatResultsMessage(report, options)
+  const client = new SlackClient(resolvedOptions)
+  const message = formatResultsMessage(report, resolvedOptions)
+  const ts = await client.sendMessage(message)
 
-  if (options.webhookUrl !== undefined) {
-    await sendSlackMessage(message, {
-      webhookUrl: options.webhookUrl,
-    })
-    if (logs) console.log('Test results message sent to Slack.')
-  } else if (
-    options.oauthToken !== undefined &&
-    options.channelId !== undefined
-  ) {
-    await postMessage(options.channelId, message, {
-      oauthToken: options.oauthToken,
-    })
-    if (logs) console.log('Test results message sent to Slack.')
-  }
+  if (logs) console.log('Test results message sent to Slack.')
+
+  if (resolvedOptions.returnTs) return ts
 }
 
 /**
@@ -57,70 +140,47 @@ export async function sendTestResultsToSlack(
  * @param report - The CTRF report
  * @param options - The options for the message
  * @param logs - Whether to log the message
+ * @returns The message timestamp if returnTs is true and using OAuth, otherwise void
  */
 export async function sendFailedResultsToSlack(
   report: CtrfReport,
   options: Options = {},
   logs: boolean = false
-): Promise<void> {
+): Promise<string | void> {
   if (report.results.summary.failed === 0) {
     return
   }
 
   report = stripAnsiFromErrors(report)
+  const resolvedOptions = resolveOptions(options)
+  const client = new SlackClient(resolvedOptions)
 
-  if (options.consolidated !== undefined && options.consolidated) {
+  if (
+    resolvedOptions.consolidated !== undefined &&
+    resolvedOptions.consolidated
+  ) {
     const message = formatConsolidatedFailedTestSummary(
       report.results.tests,
       report.results.environment,
-      options
+      resolvedOptions
     )
     if (message !== null) {
-      if (options.webhookUrl !== undefined) {
-        await sendSlackMessage(message, {
-          webhookUrl: options.webhookUrl,
-        })
-      } else if (
-        options.oauthToken !== undefined &&
-        options.channelId !== undefined
-      ) {
-        await postMessage(options.channelId, message, {
-          oauthToken: options.oauthToken,
-        })
-      }
+      const ts = await client.sendMessage(message)
       if (logs) console.log('Failed test summary sent to Slack.')
+      if (resolvedOptions.returnTs) return ts
     } else {
       if (logs) console.log('No failed test summary detected. No message sent.')
     }
   } else {
-    for (const test of report.results.tests) {
-      if (test.status === 'failed') {
-        const message = formatFailedTestSummary(
-          test,
-          report.results.environment,
-          options
-        )
-        if (message !== null) {
-          if (options.webhookUrl !== undefined) {
-            await sendSlackMessage(message, {
-              webhookUrl: options.webhookUrl,
-            })
-            if (logs) console.log('Failed test summary sent to Slack.')
-          } else if (
-            options.oauthToken !== undefined &&
-            options.channelId !== undefined
-          ) {
-            await postMessage(options.channelId, message, {
-              oauthToken: options.oauthToken,
-            })
-            if (logs) console.log('Failed test summary sent to Slack.')
-          }
-        } else {
-          if (logs)
-            console.log('No failed test summary detected. No message sent')
-        }
-      }
-    }
+    const ts = await dispatchThreadedReports(
+      client,
+      report,
+      resolvedOptions,
+      logs,
+      'Failed test report',
+      formatFailedTestSummary
+    )
+    if (resolvedOptions.returnTs) return ts
   }
 }
 
@@ -129,27 +189,20 @@ export async function sendFailedResultsToSlack(
  * @param report - The CTRF report
  * @param options - The options for the message
  * @param logs - Whether to log the message
+ * @returns The message timestamp if returnTs is true and using OAuth, otherwise void
  */
 export async function sendFlakyResultsToSlack(
   report: CtrfReport,
   options: Options = {},
   logs: boolean = false
-): Promise<void> {
-  const message = formatFlakyTestsMessage(report, options)
+): Promise<string | void> {
+  const resolvedOptions = resolveOptions(options)
+  const message = formatFlakyTestsMessage(report, resolvedOptions)
   if (message !== null) {
-    if (options.webhookUrl !== undefined) {
-      await sendSlackMessage(message, {
-        webhookUrl: options.webhookUrl,
-      })
-    } else if (
-      options.oauthToken !== undefined &&
-      options.channelId !== undefined
-    ) {
-      await postMessage(options.channelId, message, {
-        oauthToken: options.oauthToken,
-      })
-    }
+    const client = new SlackClient(resolvedOptions)
+    const ts = await client.sendMessage(message)
     if (logs) console.log('Flaky tests message sent to Slack.')
+    if (resolvedOptions.returnTs) return ts
   } else {
     if (logs) console.log('No flaky tests detected. No message sent.')
   }
@@ -160,62 +213,39 @@ export async function sendFlakyResultsToSlack(
  * @param report - The CTRF report
  * @param options - The options for the message
  * @param logs - Whether to log the message
+ * @returns The message timestamp if returnTs is true and using OAuth, otherwise void
  */
 export async function sendAISummaryToSlack(
   report: CtrfReport,
   options: Options = {},
   logs: boolean = false
-): Promise<void> {
-  if (options.consolidated !== undefined && options.consolidated) {
-    const message = formatConsolidatedAiTestSummary(
-      report.results.tests,
-      report.results.environment,
-      options
-    )
+): Promise<string | void> {
+  const resolvedOptions = resolveOptions(options)
+  const client = new SlackClient(resolvedOptions)
+
+  if (
+    resolvedOptions.consolidated !== undefined &&
+    resolvedOptions.consolidated
+  ) {
+    const message = formatConsolidatedAiTestSummary(report, resolvedOptions)
     if (message !== null) {
-      if (options.webhookUrl !== undefined) {
-        await sendSlackMessage(message, {
-          webhookUrl: options.webhookUrl,
-        })
-      } else if (
-        options.oauthToken !== undefined &&
-        options.channelId !== undefined
-      ) {
-        await postMessage(options.channelId, message, {
-          oauthToken: options.oauthToken,
-        })
-      }
+      const ts = await client.sendMessage(message)
       if (logs) console.log('AI test summary sent to Slack.')
+      if (resolvedOptions.returnTs) return ts
     } else {
       if (logs) console.log('No AI summary detected. No message sent.')
     }
   } else {
-    for (const test of report.results.tests) {
-      if (test.status === 'failed') {
-        const message = formatAiTestSummary(
-          test,
-          report.results.environment,
-          options
-        )
-        if (message !== null) {
-          if (options.webhookUrl !== undefined) {
-            await sendSlackMessage(message, {
-              webhookUrl: options.webhookUrl,
-            })
-          } else if (
-            options.oauthToken !== undefined &&
-            options.channelId !== undefined
-          ) {
-            await postMessage(options.channelId, message, {
-              oauthToken: options.oauthToken,
-            })
-          }
-          if (logs) console.log('AI test summary sent to Slack.')
-        } else {
-          if (logs) console.log('No AI summary detected. No message sent')
-        }
-      }
-    }
+    const ts = await dispatchThreadedReports(
+      client,
+      report,
+      resolvedOptions,
+      logs,
+      'AI test summary',
+      formatAiTestSummary,
+      formatGlobalAiSummary
+    )
+    if (resolvedOptions.returnTs) return ts
   }
 }
 
@@ -225,16 +255,18 @@ export async function sendAISummaryToSlack(
  * @param templateContent - The Handlebars template content
  * @param options - The options for the message
  * @param logs - Whether to log the message
+ * @returns The message timestamp if returnTs is true and using OAuth, otherwise void
  */
 export async function sendCustomMarkdownTemplateToSlack(
   report: CtrfReport,
   templateContent: string,
   options: Options = {},
   logs: boolean = false
-): Promise<void> {
+): Promise<string | void> {
+  const resolvedOptions = resolveOptions(options)
   if (
-    options.onFailOnly !== undefined &&
-    options.onFailOnly &&
+    resolvedOptions.onFailOnly !== undefined &&
+    resolvedOptions.onFailOnly &&
     report.results.summary.failed === 0
   ) {
     if (logs) console.log('No failed tests. Message not sent.')
@@ -248,23 +280,14 @@ export async function sendCustomMarkdownTemplateToSlack(
     report,
     compiledContent,
     report.results.environment,
-    options
+    resolvedOptions
   )
 
   if (message !== null) {
-    if (options.webhookUrl !== undefined) {
-      await sendSlackMessage(message, {
-        webhookUrl: options.webhookUrl,
-      })
-    } else if (
-      options.oauthToken !== undefined &&
-      options.channelId !== undefined
-    ) {
-      await postMessage(options.channelId, message, {
-        oauthToken: options.oauthToken,
-      })
-    }
+    const client = new SlackClient(resolvedOptions)
+    const ts = await client.sendMessage(message)
     if (logs) console.log('Custom template message sent to Slack.')
+    if (resolvedOptions.returnTs) return ts
   } else {
     if (logs) console.log('No custom message detected. No message sent.')
   }
@@ -273,19 +296,21 @@ export async function sendCustomMarkdownTemplateToSlack(
 /**
  * Send a custom Block Kit JSON template to Slack
  * @param report - The CTRF report
- * @param blockKitJson - The Block Kit JSON template content
+ * @param templateContent - The Handlebars template content
  * @param options - The options for the message
  * @param logs - Whether to log the message
+ * @returns The message timestamp if returnTs is true and using OAuth, otherwise void
  */
 export async function sendCustomBlockKitTemplateToSlack(
   report: CtrfReport,
   templateContent: string,
   options: Options = {},
   logs: boolean = false
-): Promise<void> {
+): Promise<string | void> {
+  const resolvedOptions = resolveOptions(options)
   if (
-    options.onFailOnly !== undefined &&
-    options.onFailOnly &&
+    resolvedOptions.onFailOnly !== undefined &&
+    resolvedOptions.onFailOnly &&
     report.results.summary.failed === 0
   ) {
     if (logs) console.log('No failed tests. Message not sent.')
@@ -306,19 +331,10 @@ export async function sendCustomBlockKitTemplateToSlack(
   const message = formatCustomBlockKitMessage(report, blockKit)
 
   if (message !== null) {
-    if (options.webhookUrl !== undefined) {
-      await sendSlackMessage(message, {
-        webhookUrl: options.webhookUrl,
-      })
-    } else if (
-      options.oauthToken !== undefined &&
-      options.channelId !== undefined
-    ) {
-      await postMessage(options.channelId, message, {
-        oauthToken: options.oauthToken,
-      })
-    }
+    const client = new SlackClient(resolvedOptions)
+    const ts = await client.sendMessage(message)
     if (logs) console.log('Custom Block Kit message sent to Slack.')
+    if (resolvedOptions.returnTs) return ts
   } else {
     if (logs)
       console.log('No custom Block Kit message detected. No message sent.')

--- a/src/types/ctrf.d.ts
+++ b/src/types/ctrf.d.ts
@@ -8,6 +8,7 @@ export interface Results {
   tests: CtrfTest[]
   environment?: CtrfEnvironment
   extra?: Record<string, unknown>
+  ai?: string
 }
 
 export interface Summary {
@@ -21,6 +22,7 @@ export interface Summary {
   start: number
   stop: number
   extra?: Record<string, unknown>
+  ai?: string
 }
 
 export interface CtrfTest {

--- a/src/types/reporter.d.ts
+++ b/src/types/reporter.d.ts
@@ -15,6 +15,9 @@ export interface Options {
   maxRetries?: number
   dryRun?: boolean
   maxReports?: number
+  react?: boolean
+  failedEmoji?: string
+  passedEmoji?: string
 }
 
 export interface SlackBlock {

--- a/src/types/reporter.d.ts
+++ b/src/types/reporter.d.ts
@@ -8,4 +8,42 @@ export interface Options {
   channelId?: string
   webhookUrl?: string
   token?: string
+  threadTs?: string
+  returnTs?: boolean
+  replyBroadcast?: boolean
+  autoThread?: boolean
+  maxRetries?: number
+  dryRun?: boolean
+  maxReports?: number
+}
+
+export interface SlackBlock {
+  type: string
+  text?: {
+    type: string
+    text: string
+    emoji?: boolean
+  }
+  accessory?: {
+    type: string
+    image_url: string
+    alt_text: string
+  }
+  elements?: Array<{
+    type: string
+    text: string
+  }>
+}
+
+export interface SlackMessage {
+  text?: string
+  blocks?: SlackBlock[]
+  attachments?: Array<{
+    fallback?: string
+    color?: string
+    blocks?: SlackBlock[]
+  }>
+  thread_ts?: string
+  reply_broadcast?: boolean
+  mrkdwn?: boolean
 }


### PR DESCRIPTION
## Summary

Adds optional emoji reactions to Slack messages after they are sent. When `react: true`, the bot adds an emoji to the message indicating whether tests passed or failed — giving a quick visual indicator directly in the channel without opening the thread.

> **Depends on** #80 (Slack threading support). Please merge that first.

### New options

| Option | CLI flag | Env var | Default |
|---|---|---|---|
| `react` | `--react` / `-r` | `SLACK_REACT` | `false` |
| `failedEmoji` | `--failed-emoji` / `-fe` | `SLACK_FAILED_EMOJI` | `x` |
| `passedEmoji` | `--passed-emoji` / `-pe` | `SLACK_PASSED_EMOJI` | `white_check_mark` |

Reactions require an **OAuth token** — the Slack reactions API is not available via incoming webhooks. If a webhook is configured, `addReaction` silently skips.

### Usage

```yaml
- name: Report results
  run: |
    npx slack-ctrf results ctrf-report.json \
      --react \
      --failed-emoji fire \
      --passed-emoji white_check_mark
```

With custom emojis from your workspace:
```yaml
- run: npx slack-ctrf results ctrf-report.json --react --failed-emoji rotating_light
```

### Behaviour

- `results` — reacts with failed emoji if any tests failed, passed emoji otherwise
- `failed` / `flaky` — always reacts with failed emoji (these commands only run when there are failures)
- `ai` — reacts based on the summary failed count
- `dry-run` mode — prints `[Dry Run] Add reaction :emoji: to message <ts>` instead of calling the API

## Test plan

- [x] `npm run build:check` — type-check passes
- [x] `npm test` — 53 tests pass (8 new reaction tests)
- [x] `npm run lint:check && npm run format:check` — CI checks pass
- [x] Manual: `npx slack-ctrf results ctrf-report.json --dry-run --react` — prints `[Dry Run] Add reaction :white_check_mark: to message dry-run-ts`
- [ ] Manual: `npx slack-ctrf results ctrf-report.json --react` with real OAuth token — reaction appears on message in Slack
- [ ] Manual: `npx slack-ctrf results ctrf-report.json --react --failed-emoji fire` with failing report — `:fire:` reaction appears

🤖 Generated with [Claude Code](https://claude.ai/code)
